### PR TITLE
Darwin specific implementation for term status

### DIFF
--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -36,4 +36,6 @@ func main() {
 		termenv.String("cyan").Foreground(p.Color("0")).Background(p.Color("#66C2CD")),
 		termenv.String("gray").Foreground(p.Color("0")).Background(p.Color("#B9BFCA")),
 	)
+
+	fmt.Printf("\n\t%s %t\n", termenv.String("Has dark background?").Bold(), termenv.HasDarkBackground())
 }

--- a/termenv_darwin.go
+++ b/termenv_darwin.go
@@ -1,0 +1,62 @@
+// +build darwin
+
+package termenv
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/google/goterm/term"
+)
+
+type Termios struct {
+	Iflag  uintptr
+	Oflag  uintptr
+	Cflag  uintptr
+	Lflag  uintptr
+	Cc     [20]byte
+	Ispeed uintptr
+	Ospeed uintptr
+}
+
+func Attr(file *os.File) (Termios, error) {
+	var t Termios
+	fd := file.Fd()
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&t)))
+	if errno != 0 {
+		return t, errno
+	}
+	return t, nil
+}
+
+func Set(t Termios, file *os.File) error {
+	fd := file.Fd()
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(&t)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func termStatusReport(sequence int) (string, error) {
+	t, err := Attr(os.Stdout)
+	if err != nil {
+		return "", ErrStatusReport
+	}
+	defer Set(t, os.Stdout)
+
+	noecho := t
+	noecho.Lflag &= term.ECHO &^ term.ICANON
+	if err := Set(noecho, os.Stdout); err != nil {
+		return "", ErrStatusReport
+	}
+	fmt.Printf("\033]%d;?\007", sequence)
+	s, ok := readWithTimeout(os.Stdout)
+	if !ok {
+		return "", ErrStatusReport
+	}
+	// fmt.Println("Rcvd", s[1:])
+	return s, nil
+}

--- a/termenv_linux.go
+++ b/termenv_linux.go
@@ -1,0 +1,33 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
+package termenv
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/goterm/term"
+)
+
+func termStatusReport(sequence int) (string, error) {
+	t, err := term.Attr(os.Stdout)
+	if err != nil {
+		return "", ErrStatusReport
+	}
+	defer t.Set(os.Stdout)
+
+	noecho := t
+	noecho.Lflag = noecho.Lflag &^ term.ECHO
+	noecho.Lflag = noecho.Lflag &^ term.ICANON
+	if err := noecho.Set(os.Stdout); err != nil {
+		return "", ErrStatusReport
+	}
+
+	fmt.Printf("\033]%d;?\007", sequence)
+	s, ok := readWithTimeout(os.Stdout)
+	if !ok {
+		return "", ErrStatusReport
+	}
+	// fmt.Println("Rcvd", s[1:])
+	return s, nil
+}

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -3,13 +3,10 @@
 package termenv
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
-
-	"github.com/google/goterm/term"
 )
 
 func colorProfile() Profile {
@@ -71,29 +68,6 @@ func backgroundColor() Color {
 
 	// default black
 	return ANSIColor(0)
-}
-
-func termStatusReport(sequence int) (string, error) {
-	t, err := term.Attr(os.Stdout)
-	if err != nil {
-		return "", ErrStatusReport
-	}
-	defer t.Set(os.Stdout)
-
-	noecho := t
-	noecho.Lflag = noecho.Lflag &^ term.ECHO
-	noecho.Lflag = noecho.Lflag &^ term.ICANON
-	if err := noecho.Set(os.Stdout); err != nil {
-		return "", ErrStatusReport
-	}
-
-	fmt.Printf("\033]%d;?\007", sequence)
-	s, ok := readWithTimeout(os.Stdout)
-	if !ok {
-		return "", ErrStatusReport
-	}
-	// fmt.Println("Rcvd", s[1:])
-	return s, nil
 }
 
 func readWithTimeout(f *os.File) (string, bool) {


### PR DESCRIPTION
On Darwin, the ioctl syscall requires the `TIOCGETA` and `TIOCSETA`
constants. The Google termios library has the Linux constants
hard-coded, so this fix reimplements some functions for Darwin.

This fixes the dark background check in OS X Terminal.