### PR TITLE
fix: add missing color to ansi256ToANSIColor

### DIFF
--- a/color.go
+++ b/color.go
@@ -169,7 +169,7 @@ func ansi256ToANSIColor(c ANSI256Color) ANSIColor {
 	md := math.MaxFloat64
 
 	h, _ := colorful.Hex(ansiHex[c])
-	for i := 0; i < 15; i++ {
+	for i := 0; i <= 15; i++ {
 		hb, _ := colorful.Hex(ansiHex[i])
 		d := h.DistanceLab(hb)
 


### PR DESCRIPTION
Previously, converting #ffffff to Ansi would return 7
(#c0c0c0) instead of 15 (#ffffff). This is because not all of the
ANSIColor ids from 0-15 were checked due to a missing `=` in the loop.