### PR TITLE
fix(templatehelper): no styles in Ascii mode

### DIFF
--- a/templatehelper.go
+++ b/templatehelper.go
@@ -6,6 +6,9 @@ import (
 
 // TemplateFuncs contains a few useful template helpers
 func TemplateFuncs(p Profile) template.FuncMap {
+	if p == Ascii {
+		return noopTemplateFuncs
+	}
 	return template.FuncMap{
 		"Color": func(values ...interface{}) string {
 			s := String(values[len(values)-1].(string))
@@ -52,4 +55,26 @@ func styleFunc(f func(Style) Style) func(...interface{}) string {
 		s := String(values[0].(string))
 		return f(s).String()
 	}
+}
+
+var noopTemplateFuncs = template.FuncMap{
+	"Color":      noColorFunc,
+	"Foreground": noColorFunc,
+	"Background": noColorFunc,
+	"Bold":       noStyleFunc,
+	"Faint":      noStyleFunc,
+	"Italic":     noStyleFunc,
+	"Underline":  noStyleFunc,
+	"Overline":   noStyleFunc,
+	"Blink":      noStyleFunc,
+	"Reverse":    noStyleFunc,
+	"CrossOut":   noStyleFunc,
+}
+
+func noColorFunc(values ...interface{}) string {
+	return values[len(values)-1].(string)
+}
+
+func noStyleFunc(values ...interface{}) string {
+	return values[0].(string)
 }

--- a/templatehelper_test.go
+++ b/templatehelper_test.go
@@ -1,0 +1,43 @@
+package termenv
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"text/template"
+)
+
+func TestTemplateFuncs(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile Profile
+	}{
+		{"ascii", Ascii},
+		{"ansi", ANSI},
+		{"ansi256", ANSI256},
+		{"truecolor", TrueColor},
+	}
+	const templateFile = "./testdata/templatehelper.tpl"
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tpl, err := template.New("templatehelper.tpl").Funcs(TemplateFuncs(test.profile)).ParseFiles(templateFile)
+			if err != nil {
+				t.Fatalf("unexpected error parsing template: %v", err)
+			}
+			var buf bytes.Buffer
+			if err = tpl.Execute(&buf, nil); err != nil {
+				t.Fatalf("unexpected error executing template: %v", err)
+			}
+			actual := buf.Bytes()
+			filename := fmt.Sprintf("./testdata/templatehelper_%s.txt", test.name)
+			expected, err := ioutil.ReadFile(filename)
+			if err != nil {
+				t.Fatalf("unexpected error reading golden file %q: %v", filename, err)
+			}
+			if !bytes.Equal(buf.Bytes(), expected) {
+				t.Fatalf("template output does not match golden file.\n--- Expected ---\n%s\n--- Actual ---\n%s\n", string(expected), string(actual))
+			}
+		})
+	}
+}

--- a/testdata/templatehelper.tpl
+++ b/testdata/templatehelper.tpl
@@ -1,0 +1,14 @@
+Plain
+{{ Color "#ff0000" "Red" }}
+{{ Color "#ff0000" "#00ff00"  "Red on Blue" }}
+{{ Foreground "#00ffff" "Cyan" }}
+{{ Background "#ff00ff" "Magenta Bg" }}
+{{ Foreground "#00ffff" (Background "#ff00ff" "Cyan on Magenta Bg") }}
+{{ Bold "Bold" }}
+{{ Faint "Faint" }}
+{{ Italic "Italic" }}
+{{ Underline "Underline" }}
+{{ Overline "Overline" }}
+{{ Blink "Blink" }}
+{{ Reverse "Reverse" }}
+{{ CrossOut "CrossOut" }}

--- a/testdata/templatehelper_ansi.txt
+++ b/testdata/templatehelper_ansi.txt
@@ -1,0 +1,14 @@
+Plain
+[91mRed[0m
+[91;102mRed on Blue[0m
+[96mCyan[0m
+[105mMagenta Bg[0m
+[96m[105mCyan on Magenta Bg[0m[0m
+[1mBold[0m
+[2mFaint[0m
+[3mItalic[0m
+[4mUnderline[0m
+[53mOverline[0m
+[5mBlink[0m
+[7mReverse[0m
+[9mCrossOut[0m

--- a/testdata/templatehelper_ansi256.txt
+++ b/testdata/templatehelper_ansi256.txt
@@ -1,0 +1,14 @@
+Plain
+[38;5;196mRed[0m
+[38;5;196;48;5;46mRed on Blue[0m
+[38;5;51mCyan[0m
+[48;5;201mMagenta Bg[0m
+[38;5;51m[48;5;201mCyan on Magenta Bg[0m[0m
+[1mBold[0m
+[2mFaint[0m
+[3mItalic[0m
+[4mUnderline[0m
+[53mOverline[0m
+[5mBlink[0m
+[7mReverse[0m
+[9mCrossOut[0m

--- a/testdata/templatehelper_ascii.txt
+++ b/testdata/templatehelper_ascii.txt
@@ -1,0 +1,14 @@
+Plain
+Red
+Red on Blue
+Cyan
+Magenta Bg
+Cyan on Magenta Bg
+Bold
+Faint
+Italic
+Underline
+Overline
+Blink
+Reverse
+CrossOut

--- a/testdata/templatehelper_truecolor.txt
+++ b/testdata/templatehelper_truecolor.txt
@@ -1,0 +1,14 @@
+Plain
+[38;2;255;0;0mRed[0m
+[38;2;255;0;0;48;2;0;255;0mRed on Blue[0m
+[38;2;0;255;255mCyan[0m
+[48;2;255;0;255mMagenta Bg[0m
+[38;2;0;255;255m[48;2;255;0;255mCyan on Magenta Bg[0m[0m
+[1mBold[0m
+[2mFaint[0m
+[3mItalic[0m
+[4mUnderline[0m
+[53mOverline[0m
+[5mBlink[0m
+[7mReverse[0m
+[9mCrossOut[0m


### PR DESCRIPTION
If the color profile doesn't support ANSI color codes, then it likely shouldn't support any Style options either. This returns a no-op funcmap from `termenv.TemplateFuncs` when the color profile is `Ascii`.