### PR TITLE
Add Profile.FromColor to convert a color.Color interface to a termenv.Color

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ p := termenv.ColorProfile()
 out = out.Foreground(p.Color("#abcdef"))
 // but also supports ANSI colors (0-255)
 out = out.Background(p.Color("69"))
+// ...or the color.Color interface
+out = out.Foreground(p.FromColor(color.RGBA{255, 128, 0, 255}))
 
 fmt.Println(out)
 ```

--- a/color.go
+++ b/color.go
@@ -3,6 +3,7 @@ package termenv
 import (
 	"errors"
 	"fmt"
+	"image/color"
 	"math"
 	"strconv"
 	"strings"
@@ -104,6 +105,11 @@ func (p Profile) Color(s string) Color {
 	}
 
 	return p.Convert(c)
+}
+
+func (p Profile) FromColor(c color.Color) Color {
+	col, _ := colorful.MakeColor(c)
+	return p.Color(col.Hex())
 }
 
 func (c NoColor) Sequence(bg bool) string {

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -3,6 +3,7 @@ package termenv
 import (
 	"bytes"
 	"fmt"
+	"image/color"
 	"os"
 	"strings"
 	"testing"
@@ -60,6 +61,7 @@ func TestRendering(t *testing.T) {
 }
 
 func TestColorConversion(t *testing.T) {
+	// ANSI color
 	a := ANSI.Color("7")
 	c := ConvertToRGB(a)
 
@@ -68,6 +70,7 @@ func TestColorConversion(t *testing.T) {
 		t.Errorf("Expected %s, got %s", exp, c.Hex())
 	}
 
+	// ANSI-256 color
 	a256 := ANSI256.Color("91")
 	c = ConvertToRGB(a256)
 
@@ -76,12 +79,22 @@ func TestColorConversion(t *testing.T) {
 		t.Errorf("Expected %s, got %s", exp, c.Hex())
 	}
 
+	// hex color
 	hex := "#abcdef"
 	argb := TrueColor.Color(hex)
 	c = ConvertToRGB(argb)
 
 	if c.Hex() != hex {
 		t.Errorf("Expected %s, got %s", exp, c.Hex())
+	}
+}
+
+func TestFromColor(t *testing.T) {
+	// color.Color interface
+	c := TrueColor.FromColor(color.RGBA{255, 128, 0, 255})
+	exp := "38;2;255;128;0"
+	if c.Sequence(false) != exp {
+		t.Errorf("Expected %s, got %s", exp, c.Sequence(false))
 	}
 }
 


### PR DESCRIPTION
Sadly, all the different color types can make naming a bit confusing. This is the best I could come up with, without breaking existing API.