### PR TITLE
Reliably query terminal on high latency connections

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -3,10 +3,8 @@
 package termenv
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -85,52 +83,81 @@ func backgroundColor() Color {
 	return ANSIColor(0)
 }
 
-func readWithTimeout(f *os.File) (string, bool) {
-	var readfds unix.FdSet
-	fd := int(f.Fd())
-	readfds.Set(fd)
-
-	for {
-		// Use select to attempt to read from os.Stdout for 100 ms
-		_, err := unix.Select(fd+1, &readfds, nil, nil, &unix.Timeval{Usec: 100000})
-		if err == nil {
-			break
-		}
-		// On MacOS we can see EINTR here if the user
-		// pressed ^Z. Similar to issue https://github.com/golang/go/issues/22838
-		if runtime.GOOS == "darwin" && err == unix.EINTR {
-			continue
-		}
-		// log.Printf("select(read error): %v", err)
-		return "", false
+func readNextByte(f *os.File) (byte, error) {
+	var b [1]byte
+	n, err := f.Read(b[:])
+	if err != nil {
+		return 0, err
 	}
 
-	if !readfds.IsSet(fd) {
-		// log.Print("select(read timeout)")
-		return "", false
+	if n == 0 {
+		panic("read returned no data")
 	}
 
-	// n > 0 => is readable
-	var data []byte
-	b := make([]byte, 1)
+	return b[0], nil
+}
+
+// readNextResponse reads either an OSC response or a cursor position response:
+//  * OSC response: "\x1b]11;rgb:1111/1111/1111\x1b\\"
+//  * cursor position response: "\x1b[42;1R"
+func readNextResponse(fd *os.File) (response string, isOSC bool, err error) {
+	// first byte must be ESC
+	start, err := readNextByte(fd)
+	if err != nil {
+		return "", false, err
+	}
+
+	if start != '\033' {
+		return "", false, ErrStatusReport
+	}
+
+	response += string(start)
+
+	// next byte is either '[' (cursor position response) or ']' (OSC response)
+	tpe, err := readNextByte(fd)
+	if err != nil {
+		return "", false, err
+	}
+
+	response += string(tpe)
+
+	var oscResponse bool
+	switch tpe {
+	case '[':
+		oscResponse = false
+	case ']':
+		oscResponse = true
+	default:
+		return "", false, ErrStatusReport
+	}
+
 	for {
-		_, err := f.Read(b)
+		b, err := readNextByte(os.Stdout)
 		if err != nil {
-			// log.Printf("read(%d): %v %d", fd, err, n)
-			return "", false
+			return "", false, err
 		}
-		// log.Printf("read %d bytes from stdout: %s %d\n", n, data, data[len(data)-1])
 
-		data = append(data, b[0])
+		response += string(b)
 
-		// data sent by terminal is either terminated by BEL (\a) or ST (ESC \)
-		if bytes.HasSuffix(data, []byte("\a")) || bytes.HasSuffix(data, []byte("\033\\")) {
+		if oscResponse {
+			// OSC can be terminated by BEL (\a) or ST (ESC \)
+			if b == '\a' || strings.HasSuffix(response, "\033\\") {
+				return response, true, nil
+			}
+		} else {
+			// cursor position response is terminated by 'R'
+			if b == 'R' {
+				return response, false, nil
+			}
+		}
+
+		// both responses have less than 25 bytes, so if we read more, that's an error
+		if len(response) > 25 {
 			break
 		}
 	}
 
-	// fmt.Printf("read %d bytes from stdout: %s\n", n, data)
-	return string(data), true
+	return "", false, ErrStatusReport
 }
 
 func termStatusReport(sequence int) (string, error) {
@@ -147,11 +174,29 @@ func termStatusReport(sequence int) (string, error) {
 		return "", ErrStatusReport
 	}
 
+	// first, send OSC query, which is ignored by terminal which do not support it
 	fmt.Printf("\033]%d;?\033\\", sequence)
-	s, ok := readWithTimeout(os.Stdout)
-	if !ok {
+
+	// then, query cursor position, should be supported by all terminals
+	fmt.Printf("\033[6n")
+
+	// read the next response
+	res, isOSC, err := readNextResponse(os.Stdout)
+	if err != nil {
+		return "", err
+	}
+
+	// if this is not OSC response, then the terminal does not support it
+	if !isOSC {
 		return "", ErrStatusReport
 	}
+
+	// read the cursor query response next and discard the result
+	_, _, err = readNextResponse(os.Stdout)
+	if err != nil {
+		return "", err
+	}
+
 	// fmt.Println("Rcvd", s[1:])
-	return s, nil
+	return res, nil
 }


### PR DESCRIPTION
Queries to the terminal are sent and the response is read with a timeout of 100ms. If the latency between the program (running on a remote server) and the terminal (running on a user's workstation) is larger than 100ms, this fails and the program may be finished when the response can finally be read.

This commit replaces the timeout-based approach. Two queries are sent to the terminal: first, the query we're interested in, but which may not be supported by the terminal. If it isn't, the terminal will silently ignore the request and not respond at all.

Next, a cursor position query is sent. This should be supported by all terminals.

Then a response is read without a timeout. Either the terminal responds with the cursor position, then we know it does not support the OSC query and we can abort. If an OSC response is read, we have our result and we just need to read the cursor position response and discard it.

This approach will work regardless of latency. Since we know that the terminal will respond (at least to the cursor position request), there's no need for a timeout, so we can even remove the call to select().

The approach can be tested on Linux by adding e.g. 200ms of artificial latency via `tc` and running a program on a remote host:

    tc qdisc add dev eth0 root netem delay 200ms 10ms

The latency can be cleared as follows:

    tc qdisc del root dev eth0

I've tested this on Linux only so far, but I'm confident it will work on macOS, too.

This resolves https://github.com/muesli/duf/issues/84