### PR TITLE
Detect screen/tmux sessions

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -134,6 +134,11 @@ func readWithTimeout(f *os.File) (string, bool) {
 }
 
 func termStatusReport(sequence int) (string, error) {
+	term := os.Getenv("TERM")
+	if strings.HasPrefix(term, "screen") {
+		return "", ErrStatusReport
+	}
+
 	t, err := unix.IoctlGetTermios(unix.Stdout, tcgetattr)
 	if err != nil {
 		return "", ErrStatusReport


### PR DESCRIPTION
As discussed in #27, screen/tmux sessions prevent us from executing
terminal status reports reliably. This change detects whether we're
running in such a session and prevents the report from being queried.

This in turn will make termenv rely on environment variables for
foreground/background detection.