### PR TITLE
Support backslash-less report termination, as used by rxvt

### DIFF
--- a/color.go
+++ b/color.go
@@ -160,6 +160,8 @@ func xTermColor(s string) (RGBColor, error) {
 	switch {
 	case strings.HasSuffix(s, "\a"):
 		s = strings.TrimSuffix(s, "\a")
+	case strings.HasSuffix(s, "\033"):
+		s = strings.TrimSuffix(s, "\033")
 	case strings.HasSuffix(s, "\033\\"):
 		s = strings.TrimSuffix(s, "\033\\")
 	default:

--- a/color_test.go
+++ b/color_test.go
@@ -9,6 +9,11 @@ func TestXTermColor(t *testing.T) {
 		valid bool
 	}{
 		{
+			"\033]11;rgb:fafa/fafa/fafa\033",
+			RGBColor("#fafafa"),
+			true,
+		},
+		{
 			"\033]11;rgb:fafa/fafa/fafa\033\\",
 			RGBColor("#fafafa"),
 			true,


### PR DESCRIPTION
Tested with konsole, gnome-terminal, rxvt, kitty, Hyper, iTerm2, Apple Terminal, ...