### PR TITLE
Add AdaptiveFaint, ForceFaint and HasDarkColorScheme

### DIFF
--- a/examples/faint/main.go
+++ b/examples/faint/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/muesli/termenv"
+)
+
+func main() {
+	var s termenv.Style
+
+	compare(s)
+
+	for i := 1; i < 255; i++ {
+		if i < 16 {
+			compare(s.Foreground(termenv.ANSIColor(i)))
+		} else {
+			compare(s.Foreground(termenv.ANSI256Color(i)))
+		}
+	}
+}
+
+func compare(s termenv.Style) {
+	fmt.Print(s.Styled("Regular") + " | ")
+	fmt.Print(s.Faint().Styled("Faint") + " | ")
+	fmt.Print(s.ForceFaint().Styled("Forced") + " | ")
+	fmt.Print(s.AdaptiveFaint().Styled("Adaptive"))
+	fmt.Println()
+}

--- a/style.go
+++ b/style.go
@@ -1,7 +1,6 @@
 package termenv
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -22,7 +21,9 @@ const (
 // Style is a string that various rendering styles can be applied to.
 type Style struct {
 	string
-	styles []string
+	fgColor  Color
+	bgColor  Color
+	modifier []modifier
 }
 
 // String returns a new Style.
@@ -38,83 +39,173 @@ func (t Style) String() string {
 
 // Styled renders s with all applied styles.
 func (t Style) Styled(s string) string {
-	if len(t.styles) == 0 {
+	if len(t.modifier) == 0 && isNoColor(t.bgColor) && isNoColor(t.fgColor) {
 		return s
 	}
 
-	seq := strings.Join(t.styles, ";")
-	if seq == "" {
-		return s
+	var builder strings.Builder
+
+	builder.WriteString(CSI)
+
+	for _, mod := range t.modifier {
+		builder.WriteString(mod(&t))
 	}
 
-	return fmt.Sprintf("%s%sm%s%sm", CSI, seq, s, CSI+ResetSeq)
+	if !isNoColor(t.fgColor) {
+		builder.WriteString(t.fgColor.Sequence(false) + ";")
+	}
+
+	if !isNoColor(t.bgColor) {
+		builder.WriteString(t.bgColor.Sequence(true) + ";")
+	}
+
+	builder.WriteString("m" + s + CSI + ResetSeq + "m")
+
+	return builder.String()
 }
 
 // Foreground sets a foreground color.
 func (t Style) Foreground(c Color) Style {
-	if c != nil {
-		t.styles = append(t.styles, c.Sequence(false))
-	}
+	t.fgColor = c
+
 	return t
 }
 
 // Background sets a background color.
 func (t Style) Background(c Color) Style {
-	if c != nil {
-		t.styles = append(t.styles, c.Sequence(true))
-	}
+	t.bgColor = c
+
 	return t
 }
 
 // Bold enables bold rendering.
 func (t Style) Bold() Style {
-	t.styles = append(t.styles, BoldSeq)
+	t.modifier = append(t.modifier, newModifier(BoldSeq))
 	return t
 }
 
 // Faint enables faint rendering.
 func (t Style) Faint() Style {
-	t.styles = append(t.styles, FaintSeq)
+	t.modifier = append(t.modifier, newModifier(FaintSeq))
 	return t
+}
+
+func (t Style) ForcedFaint() Style {
+	t.modifier = append(t.modifier, func(s *Style) string {
+		bgColor := s.backgroundColor()
+		fgColor := s.foregroundColor()
+
+		*s = s.Foreground(blend(fgColor, bgColor))
+
+		return ""
+	})
+
+	return t
+}
+
+func (t Style) AdaptiveFaint() Style {
+	t.modifier = append(t.modifier, func(s *Style) string {
+		bgColor := s.backgroundColor()
+		fgColor := s.foregroundColor()
+
+		if isDarker(bgColor, fgColor) || (bgColor == NoColor{}) || (fgColor == NoColor{}) {
+			return FaintSeq + ";"
+		}
+
+		*s = s.Foreground(blend(fgColor, bgColor))
+
+		return ""
+	})
+
+	return t
+}
+
+func (t *Style) foregroundColor() Color {
+	if t.fgColor != nil {
+		return t.fgColor
+	}
+
+	return ForegroundColor()
+}
+
+func (t *Style) backgroundColor() Color {
+	if t.bgColor != nil {
+		return t.bgColor
+	}
+
+	return BackgroundColor()
+}
+
+func blend(c1 Color, c2 Color) Color {
+	profile := colorProfile()
+
+	if (c1 == NoColor{}) || (c2 == NoColor{}) {
+		if profile != Ascii {
+			return ANSIColor(8)
+		}
+
+		return NoColor{}
+	}
+
+	c1Rgb := ConvertToRGB(c1)
+	c2Rgb := ConvertToRGB(c2)
+
+	return profile.FromColor(c1Rgb.BlendRgb(c2Rgb, 0.5))
 }
 
 // Italic enables italic rendering.
 func (t Style) Italic() Style {
-	t.styles = append(t.styles, ItalicSeq)
+	t.modifier = append(t.modifier, newModifier(ItalicSeq))
 	return t
 }
 
 // Underline enables underline rendering.
 func (t Style) Underline() Style {
-	t.styles = append(t.styles, UnderlineSeq)
+	t.modifier = append(t.modifier, newModifier(UnderlineSeq))
 	return t
 }
 
 // Overline enables overline rendering.
 func (t Style) Overline() Style {
-	t.styles = append(t.styles, OverlineSeq)
+	t.modifier = append(t.modifier, newModifier(OverlineSeq))
 	return t
 }
 
 // Blink enables blink mode.
 func (t Style) Blink() Style {
-	t.styles = append(t.styles, BlinkSeq)
+	t.modifier = append(t.modifier, newModifier(BlinkSeq))
 	return t
 }
 
 // Reverse enables reverse color mode.
 func (t Style) Reverse() Style {
-	t.styles = append(t.styles, ReverseSeq)
+	t.modifier = append(t.modifier, newModifier(ReverseSeq))
 	return t
 }
 
 // CrossOut enables crossed-out rendering.
 func (t Style) CrossOut() Style {
-	t.styles = append(t.styles, CrossOutSeq)
+	t.modifier = append(t.modifier, newModifier(CrossOutSeq))
 	return t
 }
 
 // Width returns the width required to print all runes in Style.
 func (t Style) Width() int {
 	return runewidth.StringWidth(t.string)
+}
+
+type modifier func(*Style) string
+
+func newModifier(sequence string) modifier {
+	return func(*Style) string {
+		if sequence == "" {
+			return sequence
+		}
+
+		return sequence + ";"
+	}
+}
+
+func isNoColor(c Color) bool {
+	return c == nil || c == NoColor{}
 }

--- a/templatehelper.go
+++ b/templatehelper.go
@@ -38,7 +38,7 @@ func TemplateFuncs(p Profile) template.FuncMap {
 		},
 		"Bold":          styleFunc(Style.Bold),
 		"Faint":         styleFunc(Style.Faint),
-		"ForcedFaint":   styleFunc(Style.ForcedFaint),
+		"ForceFaint":    styleFunc(Style.ForceFaint),
 		"AdaptiveFaint": styleFunc(Style.AdaptiveFaint),
 		"Italic":        styleFunc(Style.Italic),
 		"Underline":     styleFunc(Style.Underline),

--- a/templatehelper.go
+++ b/templatehelper.go
@@ -36,14 +36,16 @@ func TemplateFuncs(p Profile) template.FuncMap {
 
 			return s.String()
 		},
-		"Bold":      styleFunc(Style.Bold),
-		"Faint":     styleFunc(Style.Faint),
-		"Italic":    styleFunc(Style.Italic),
-		"Underline": styleFunc(Style.Underline),
-		"Overline":  styleFunc(Style.Overline),
-		"Blink":     styleFunc(Style.Blink),
-		"Reverse":   styleFunc(Style.Reverse),
-		"CrossOut":  styleFunc(Style.CrossOut),
+		"Bold":          styleFunc(Style.Bold),
+		"Faint":         styleFunc(Style.Faint),
+		"ForcedFaint":   styleFunc(Style.ForcedFaint),
+		"AdaptiveFaint": styleFunc(Style.AdaptiveFaint),
+		"Italic":        styleFunc(Style.Italic),
+		"Underline":     styleFunc(Style.Underline),
+		"Overline":      styleFunc(Style.Overline),
+		"Blink":         styleFunc(Style.Blink),
+		"Reverse":       styleFunc(Style.Reverse),
+		"CrossOut":      styleFunc(Style.CrossOut),
 	}
 }
 

--- a/termenv.go
+++ b/termenv.go
@@ -7,9 +7,7 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-var (
-	ErrStatusReport = errors.New("unable to retrieve status report")
-)
+var ErrStatusReport = errors.New("unable to retrieve status report")
 
 type Profile int
 
@@ -55,6 +53,16 @@ func HasDarkBackground() bool {
 	c := ConvertToRGB(BackgroundColor())
 	_, _, l := c.Hsl()
 	return l < 0.5
+}
+
+func HasDarkColorScheme() bool {
+	return isDarker(BackgroundColor(), ForegroundColor())
+}
+
+func isDarker(this, other Color) bool {
+	_, _, thisLightness := ConvertToRGB(this).Hsl()
+	_, _, otherLightness := ConvertToRGB(other).Hsl()
+	return thisLightness < otherLightness
 }
 
 // EnvNoColor returns true if the environment variables explicitly disable color output

--- a/termenv.go
+++ b/termenv.go
@@ -55,10 +55,15 @@ func HasDarkBackground() bool {
 	return l < 0.5
 }
 
+// HasDarkColorScheme returns true if the current background color is darker
+// than the current foreground color.
 func HasDarkColorScheme() bool {
 	return isDarker(BackgroundColor(), ForegroundColor())
 }
 
+// isDarker returns true when the lightness of the color in the first argument
+// is lower than the lightness of the color in the second argument in the HSL
+// color space.
 func isDarker(this, other Color) bool {
 	_, _, thisLightness := ConvertToRGB(this).Hsl()
 	_, _, otherLightness := ConvertToRGB(other).Hsl()

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -47,7 +47,7 @@ func TestRendering(t *testing.T) {
 	out = out.Underline()
 	out = out.Blink()
 
-	exp := "\x1b[1;3;2;4;5;38;2;171;205;239;48;5;69;mfoobar\x1b[0m"
+	exp := "\x1b[1;3;2;4;5;38;2;171;205;239;48;5;69mfoobar\x1b[0m"
 	if out.String() != exp {
 		t.Errorf("Expected %s, got %s", exp, out.String())
 	}
@@ -201,7 +201,7 @@ func TestTrueColorProfile(t *testing.T) {
 func TestStyles(t *testing.T) {
 	s := String("foobar").Foreground(TrueColor.Color("2"))
 
-	exp := "\x1b[32;mfoobar\x1b[0m"
+	exp := "\x1b[32mfoobar\x1b[0m"
 	if s.String() != exp {
 		t.Errorf("Expected %s %q, got %s %q", exp, exp, s.String(), s.String())
 	}

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -47,7 +47,7 @@ func TestRendering(t *testing.T) {
 	out = out.Underline()
 	out = out.Blink()
 
-	exp := "\x1b[38;2;171;205;239;48;5;69;1;3;2;4;5mfoobar\x1b[0m"
+	exp := "\x1b[1;3;2;4;5;38;2;171;205;239;48;5;69;mfoobar\x1b[0m"
 	if out.String() != exp {
 		t.Errorf("Expected %s, got %s", exp, out.String())
 	}
@@ -201,9 +201,9 @@ func TestTrueColorProfile(t *testing.T) {
 func TestStyles(t *testing.T) {
 	s := String("foobar").Foreground(TrueColor.Color("2"))
 
-	exp := "\x1b[32mfoobar\x1b[0m"
+	exp := "\x1b[32;mfoobar\x1b[0m"
 	if s.String() != exp {
-		t.Errorf("Expected %s, got %s", exp, s.String())
+		t.Errorf("Expected %s %q, got %s %q", exp, exp, s.String(), s.String())
 	}
 }
 


### PR DESCRIPTION
This PR addresses #44 and #45 by adding the `AdaptiveFaint` and `ForceFaint` methods on the `Style` struct. The differences to the classic `Faint` method are well documented. It also adds `HasDarkColorScheme` as the underlying functionality is needed for the faint methods and and example to compare the effects of the three faint methods.

I tried all of the color blend methods provided by `go-colorful` and found that an RGB blend with a factor of `0.5` produces the best results and is most in line with the terminals I tested.

I had to modify the internals of `Style` as `AdaptiveFaint` and `ForceFaint` are post-processing effects that are tricky to implement with the copy semantics of `Style`.

Here's an excerpt from the example using iTerm:

<img width="399" alt="image" src="https://user-images.githubusercontent.com/14264874/129453504-14360a03-3b2d-40ce-832f-a662abf17bf6.png">
