### PR TITLE
Correctly parse COLORFGBG with three values

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -74,7 +74,7 @@ func backgroundColor() Color {
 	colorFGBG := os.Getenv("COLORFGBG")
 	if strings.Contains(colorFGBG, ";") {
 		c := strings.Split(colorFGBG, ";")
-		i, err := strconv.Atoi(c[1])
+		i, err := strconv.Atoi(c[len(c)-1])
 		if err == nil {
 			return ANSIColor(i)
 		}


### PR DESCRIPTION
(u)rxvt and others set three values here: `<foreground>;<alternative-foreground>;<background>`. We're only interested in the first and last value.