### PR TITLE
Add 'kitty' and 'ansi' values as a fallback color support detection

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -30,10 +30,18 @@ func colorProfile() Profile {
 		return ANSI256
 	}
 
+	switch term {
+	case "xterm-kitty":
+		return TrueColor
+	}
+
 	if strings.Contains(term, "256color") {
 		return ANSI256
 	}
 	if strings.Contains(term, "color") {
+		return ANSI
+	}
+	if strings.Contains(term, "ansi") {
 		return ANSI
 	}
 


### PR DESCRIPTION
`ansi` being an option for macOS Terminal, `kitty` sometimes comes without a `COLORTERM` env var being set.