### PR TITLE
screen sessions should always support ANSI256

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -35,10 +35,13 @@ func colorProfile() Profile {
 	case "24bit":
 		fallthrough
 	case "truecolor":
-		if term == "screen" || !strings.HasPrefix(term, "screen") {
-			// enable TrueColor in tmux, but not for old-school screen
-			return TrueColor
+		if strings.HasPrefix(term, "screen") {
+			// tmux supports TrueColor, screen only ANSI256
+			if os.Getenv("TERM_PROGRAM") != "tmux" {
+				return ANSI256
+			}
 		}
+		return TrueColor
 	case "yes":
 		fallthrough
 	case "true":


### PR DESCRIPTION
Prevents falling back to Ascii for screen sessions that don't have the underlying terminal appended to the `TERM` env var.