### PR TITLE
Support CLICOLOR_FORCE to force colors without TTY

### DIFF
--- a/termenv.go
+++ b/termenv.go
@@ -32,6 +32,10 @@ const (
 )
 
 func isTTY(fd uintptr) bool {
+	if cliColorForced() {
+		return true
+	}
+
 	if len(os.Getenv("CI")) > 0 {
 		return false
 	}


### PR DESCRIPTION
If termenv is used without a TTY, the output will never be colored. In
some cases, such as in automated tests, there should be a way to force
colored output, even when the environment does not support it.

According to https://bixense.com/clicolors/, CLICOLOR_FORCE variable
does exactly that:

    CLICOLOR_FORCE != 0
	ANSI colors should be enabled no matter what.



Please let me know what you think.
Closes #69 