### PR TITLE
Support foreground detection on Solaris/illumos

### DIFF
--- a/termenv_posix.go
+++ b/termenv_posix.go
@@ -1,0 +1,17 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package termenv
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func isForeground(fd int) bool {
+	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if err != nil {
+		return false
+	}
+
+	return pgrp == unix.Getpgrp()
+}

--- a/termenv_solaris.go
+++ b/termenv_solaris.go
@@ -1,0 +1,22 @@
+//go:build solaris || illumos
+// +build solaris illumos
+
+package termenv
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func isForeground(fd int) bool {
+	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if err != nil {
+		return false
+	}
+
+	g, err := unix.Getpgrp()
+	if err != nil {
+		return false
+	}
+
+	return pgrp == g
+}

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -18,15 +18,6 @@ const (
 	OSCTimeout = 5 * time.Second
 )
 
-func isForeground(fd int) bool {
-	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
-	if err != nil {
-		return false
-	}
-
-	return pgrp == unix.Getpgrp()
-}
-
 func colorProfile() Profile {
 	term := os.Getenv("TERM")
 	colorTerm := os.Getenv("COLORTERM")


### PR DESCRIPTION
Solaris/illumos deviate from the posix `getpgrp` call and can return an additional error.

Fixes #72.