### PR TITLE
Added GetCursorPosition() which returns row and column number for cursor's position

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ This returns one of the supported color profiles:
 - `termenv.ANSI256` - Extended 256 color ANSI support
 - `termenv.TrueColor` - RGB/TrueColor support
 
+Alternatively, you can use `termenv.EnvColorProfile` which evaluates the
+terminal like `ColorProfile`, but also respects the `NO_COLOR` and
+`CLICOLOR_FORCE` environment variables.
+
 You can also query the terminal for its color scheme, so you know whether your
 app is running in a light- or dark-themed environment:
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ termenv.SaveCursorPosition()
 // Restore a saved cursor position
 termenv.RestoreCursorPosition()
 
+// Gets the current cursor position
+row, column, err := termenv.GetCursorPosition()
+
 // Move the cursor up a given number of lines
 termenv.CursorUp(n)
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-runewidth v0.0.13
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,6 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/screen.go
+++ b/screen.go
@@ -209,7 +209,7 @@ func EnableMousePress() {
 
 // DisableMousePress disables X10 mouse mode.
 func DisableMousePress() {
-	fmt.Print(CSI + EnableMousePressSeq)
+	fmt.Print(CSI + DisableMousePressSeq)
 }
 
 // EnableMouse enables Mouse Tracking mode.

--- a/screen.go
+++ b/screen.go
@@ -1,7 +1,14 @@
 package termenv
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -16,6 +23,7 @@ const (
 	CursorPreviousLineSeq    = "%dF"
 	CursorHorizontalSeq      = "%dG"
 	CursorPositionSeq        = "%d;%dH"
+	GetCursorPosition        = "%c[6n"
 	EraseDisplaySeq          = "%dJ"
 	EraseLineSeq             = "%dK"
 	ScrollUpSeq              = "%dS"
@@ -255,4 +263,65 @@ func DisableMouseAllMotion() {
 // SetWindowTitle sets the terminal window title.
 func SetWindowTitle(title string) {
 	fmt.Printf(OSC+SetWindowTitleSeq, title)
+}
+
+// GetPosition return the current position of the cursor on a terminal window in (row, column) format.
+func GetPosition() (int, int, error) {
+	/* The method this function uses is a bit out of ordinary. Essentially, it changes
+	the command line to 'raw' mode, then prints an ANSI special character
+	"\033[6n" in the terminal. The terminal then prints the cursor's position
+	in this format: row;columnR . This function then parses this output to get row and
+	column numbers. Finally, turns back the terminal mode from 'raw' to 'normal'.
+	*/
+
+	var row int
+	var col int
+	// Set the terminal to raw mode (to be undone with `-raw`)
+	rawMode := exec.Command("/bin/stty", "raw")
+	rawMode.Stdin = os.Stdin
+	_ = rawMode.Run()
+	err := rawMode.Wait()
+	if err != nil {
+		return -1, -1, err
+	}
+
+	// Running command $ echo -e "\033[6n" | read -dR
+	cmd := exec.Command("echo", fmt.Sprintf(GetCursorPosition, 27))
+	randomBytes := &bytes.Buffer{}
+	cmd.Stdout = randomBytes
+
+	// Start command asynchronously
+	_ = cmd.Start()
+
+	// capture keyboard output from echo command
+	reader := bufio.NewReader(os.Stdin)
+	err = cmd.Wait()
+	if err != nil {
+		return -1, -1, err
+	}
+
+	// by printing the command output, we are triggering input
+	fmt.Print(randomBytes)
+	text, _ := reader.ReadSlice('R') // The output ends with 'R'
+
+	// check for the desired output
+	if strings.Contains(string(text), ";") {
+		re := regexp.MustCompile(`\d+;\d+`)
+		line := re.FindString(string(text))
+		delimiters := strings.Split(line, ";")
+		// converting row and col strings to int
+		row, _ = strconv.Atoi(delimiters[0])
+		col, _ = strconv.Atoi(delimiters[1])
+	} else {
+		return -1, -1, errors.New("Could not parse cursor position output.")
+	}
+	// Set the terminal back from raw mode to 'normal'
+	rawModeOff := exec.Command("/bin/stty", "-raw")
+	rawModeOff.Stdin = os.Stdin
+	_ = rawModeOff.Run()
+	err = rawModeOff.Wait()
+	if err != nil {
+		return -1, -1, err
+	}
+	return row, col, err
 }

--- a/termenv_other.go
+++ b/termenv_other.go
@@ -1,5 +1,5 @@
-//go:build js
-// +build js
+//go:build js || plan9 || aix
+// +build js plan9 aix
 
 package termenv
 

--- a/termenv_posix.go
+++ b/termenv_posix.go
@@ -1,0 +1,17 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package termenv
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func isForeground(fd int) bool {
+	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if err != nil {
+		return false
+	}
+
+	return pgrp == unix.Getpgrp()
+}

--- a/termenv_solaris.go
+++ b/termenv_solaris.go
@@ -1,0 +1,22 @@
+//go:build solaris || illumos
+// +build solaris illumos
+
+package termenv
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func isForeground(fd int) bool {
+	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if err != nil {
+		return false
+	}
+
+	g, err := unix.Getpgrp()
+	if err != nil {
+		return false
+	}
+
+	return pgrp == g
+}

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -18,15 +18,6 @@ const (
 	OSCTimeout = 5 * time.Second
 )
 
-func isForeground(fd int) bool {
-	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
-	if err != nil {
-		return false
-	}
-
-	return pgrp == unix.Getpgrp()
-}
-
 func colorProfile() Profile {
 	term := os.Getenv("TERM")
 	colorTerm := os.Getenv("COLORTERM")

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -35,10 +35,13 @@ func colorProfile() Profile {
 	case "24bit":
 		fallthrough
 	case "truecolor":
-		if term == "screen" || !strings.HasPrefix(term, "screen") {
-			// enable TrueColor in tmux, but not for old-school screen
-			return TrueColor
+		if strings.HasPrefix(term, "screen") {
+			// tmux supports TrueColor, screen only ANSI256
+			if os.Getenv("TERM_PROGRAM") != "tmux" {
+				return ANSI256
+			}
 		}
+		return TrueColor
 	case "yes":
 		fallthrough
 	case "true":

--- a/termenv_windows.go
+++ b/termenv_windows.go
@@ -51,7 +51,7 @@ func backgroundColor() Color {
 
 // EnableWindowsANSIConsole enables virtual terminal processing on Windows
 // platforms. This allows the use of ANSI escape sequences in Windows console
-//  applications. Ensure this gets called before anything gets rendered with
+// applications. Ensure this gets called before anything gets rendered with
 // termenv.
 //
 // Returns the original console mode and an error if one occurred.


### PR DESCRIPTION
Added GetCursorPosition which returns `row`, `column` or `error` for the current position of the cursor on the terminal.
This is especially useful when users print unpredictable amount of output to terminal and want to clear lines but don't know how many lines have been printed.

The function uses the sequence "\033[6n" to get cursor's position and then parses the output. The method to get the output from terminal is a bit unorthodox but it had to be because interacting with terminal and reading its output is not straightforward.

This implementation was heavily inspired by [this conversation](https://groups.google.com/g/golang-nuts/c/O0-M2sQ0Io4) but open to any suggestions or improvements so that getting cursor's position gets added to termenv.