### PR TITLE
Add autodetection features based on env vars for better wish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,15 @@ color conversions.
 go get github.com/muesli/termenv
 ```
 
-## Query Terminal Support
-
-`termenv` can query the terminal it is running in, so you can safely use
-advanced features, like RGB colors. `ColorProfile` returns the color profile
-supported by the terminal:
+## Usage
 
 ```go
-profile := termenv.ColorProfile()
+output := termenv.NewOuput(os.Stdout)
 ```
 
-This returns one of the supported color profiles:
+`termenv` queries the terminal's capabilities it is running in, so you can
+safely use advanced features, like RGB colors or ANSI styles. `output.Profile`
+returns the supported profile:
 
 - `termenv.Ascii` - no ANSI support detected, ASCII only
 - `termenv.ANSI` - 16 color ANSI support
@@ -53,39 +51,46 @@ app is running in a light- or dark-themed environment:
 
 ```go
 // Returns terminal's foreground color
-color := termenv.ForegroundColor()
+color := output.ForegroundColor()
 
 // Returns terminal's background color
-color := termenv.BackgroundColor()
+color := output.BackgroundColor()
 
 // Returns whether terminal uses a dark-ish background
-darkTheme := termenv.HasDarkBackground()
+darkTheme := output.HasDarkBackground()
+```
+
+### Manual Profile Selection
+
+If you don't want to rely on the automatic detection, you can manually select
+the profile you want to use:
+
+```go
+output := termenv.NewOuputWithProfile(os.Stdout, termenv.TrueColor)
 ```
 
 ## Colors
 
-`termenv` supports multiple color profiles: ANSI (16 colors), ANSI Extended
-(256 colors), and TrueColor (24-bit RGB). Colors will automatically be degraded
-to the best matching available color in the desired profile:
+`termenv` supports multiple color profiles: Ascii (black & white only),
+ANSI (16 colors), ANSI Extended (256 colors), and TrueColor (24-bit RGB). Colors
+will automatically be degraded to the best matching available color in the
+desired profile:
 
 `TrueColor` => `ANSI 256 Colors` => `ANSI 16 Colors` => `Ascii`
 
 ```go
-s := termenv.String("Hello World")
-
-// Retrieve color profile supported by terminal
-p := termenv.ColorProfile()
+s := output.String("Hello World")
 
 // Supports hex values
 // Will automatically degrade colors on terminals not supporting RGB
-s.Foreground(p.Color("#abcdef"))
+s.Foreground(output.Color("#abcdef"))
 // but also supports ANSI colors (0-255)
-s.Background(p.Color("69"))
+s.Background(output.Color("69"))
 // ...or the color.Color interface
-s.Foreground(p.FromColor(color.RGBA{255, 128, 0, 255}))
+s.Foreground(output.FromColor(color.RGBA{255, 128, 0, 255}))
 
 // Combine fore- & background colors
-s.Foreground(p.Color("#ffffff")).Background(p.Color("#0000ff"))
+s.Foreground(output.Color("#ffffff")).Background(output.Color("#0000ff"))
 
 // Supports the fmt.Stringer interface
 fmt.Println(s)
@@ -96,7 +101,7 @@ fmt.Println(s)
 You can use a chainable syntax to compose your own styles:
 
 ```go
-s := termenv.String("foobar")
+s := output.String("foobar")
 
 // Text styles
 s.Bold()
@@ -120,7 +125,7 @@ s.Bold().Underline()
 
 ```go
 // load template helpers
-f := termenv.TemplateFuncs(termenv.ColorProfile())
+f := termenv.TemplateFuncs(output.Profile)
 tpl := template.New("tpl").Funcs(f)
 
 // apply bold style in a template
@@ -149,128 +154,128 @@ Other available helper functions are: `Faint`, `Italic`, `CrossOut`,
 
 ```go
 // Move the cursor to a given position
-termenv.MoveCursor(row, column)
+output.MoveCursor(row, column)
 
 // Save the cursor position
-termenv.SaveCursorPosition()
+output.SaveCursorPosition()
 
 // Restore a saved cursor position
-termenv.RestoreCursorPosition()
+output.RestoreCursorPosition()
 
 // Move the cursor up a given number of lines
-termenv.CursorUp(n)
+output.CursorUp(n)
 
 // Move the cursor down a given number of lines
-termenv.CursorDown(n)
+output.CursorDown(n)
 
 // Move the cursor up a given number of lines
-termenv.CursorForward(n)
+output.CursorForward(n)
 
 // Move the cursor backwards a given number of cells
-termenv.CursorBack(n)
+output.CursorBack(n)
 
 // Move the cursor down a given number of lines and place it at the beginning
 // of the line
-termenv.CursorNextLine(n)
+output.CursorNextLine(n)
 
 // Move the cursor up a given number of lines and place it at the beginning of
 // the line
-termenv.CursorPrevLine(n)
+output.CursorPrevLine(n)
 ```
 
 ## Screen
 
 ```go
 // Reset the terminal to its default style, removing any active styles
-termenv.Reset()
+output.Reset()
 
 // RestoreScreen restores a previously saved screen state
-termenv.RestoreScreen()
+output.RestoreScreen()
 
 // SaveScreen saves the screen state
-termenv.SaveScreen()
+output.SaveScreen()
 
 // Switch to the altscreen. The former view can be restored with ExitAltScreen()
-termenv.AltScreen()
+output.AltScreen()
 
 // Exit the altscreen and return to the former terminal view
-termenv.ExitAltScreen()
+output.ExitAltScreen()
 
 // Clear the visible portion of the terminal
-termenv.ClearScreen()
+output.ClearScreen()
 
 // Clear the current line
-termenv.ClearLine()
+output.ClearLine()
 
 // Clear a given number of lines
-termenv.ClearLines(n)
+output.ClearLines(n)
 
 // Set the scrolling region of the terminal
-termenv.ChangeScrollingRegion(top, bottom)
+output.ChangeScrollingRegion(top, bottom)
 
 // Insert the given number of lines at the top of the scrollable region, pushing
 // lines below down
-termenv.InsertLines(n)
+output.InsertLines(n)
 
 // Delete the given number of lines, pulling any lines in the scrollable region
 // below up
-termenv.DeleteLines(n)
+output.DeleteLines(n)
 ```
 
 ## Session
 
 ```go
 // SetWindowTitle sets the terminal window title
-termenv.SetWindowTitle(title)
+output.SetWindowTitle(title)
 
 // SetForegroundColor sets the default foreground color
-termenv.SetForegroundColor(color)
+output.SetForegroundColor(color)
 
 // SetBackgroundColor sets the default background color
-termenv.SetBackgroundColor(color)
+output.SetBackgroundColor(color)
 
 // SetCursorColor sets the cursor color
-termenv.SetCursorColor(color)
+output.SetCursorColor(color)
 
 // Hide the cursor
-termenv.HideCursor()
+output.HideCursor()
 
 // Show the cursor
-termenv.ShowCursor()
+output.ShowCursor()
 ```
 
 ## Mouse
 
 ```go
 // Enable X10 mouse mode, only button press events are sent
-termenv.EnableMousePress()
+output.EnableMousePress()
 
 // Disable X10 mouse mode
-termenv.DisableMousePress()
+output.DisableMousePress()
 
 // Enable Mouse Tracking mode
-termenv.EnableMouse()
+output.EnableMouse()
 
 // Disable Mouse Tracking mode
-termenv.DisableMouse()
+output.DisableMouse()
 
 // Enable Hilite Mouse Tracking mode
-termenv.EnableMouseHilite()
+output.EnableMouseHilite()
 
 // Disable Hilite Mouse Tracking mode
-termenv.DisableMouseHilite()
+output.DisableMouseHilite()
 
 // Enable Cell Motion Mouse Tracking mode
-termenv.EnableMouseCellMotion()
+output.EnableMouseCellMotion()
 
 // Disable Cell Motion Mouse Tracking mode
-termenv.DisableMouseCellMotion()
+output.DisableMouseCellMotion()
 
 // Enable All Motion Mouse mode
-termenv.EnableMouseAllMotion()
+output.EnableMouseAllMotion()
 
 // Disable All Motion Mouse mode
-termenv.DisableMouseAllMotion()
+output.DisableMouseAllMotion()
 ```
 
 ## Optional Feature Support

--- a/color.go
+++ b/color.go
@@ -3,9 +3,7 @@ package termenv
 import (
 	"errors"
 	"fmt"
-	"image/color"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/lucasb-eyer/go-colorful"
@@ -67,72 +65,6 @@ func ConvertToRGB(c Color) colorful.Color {
 
 	ch, _ := colorful.Hex(hex)
 	return ch
-}
-
-// Convert transforms a given Color to a Color supported within the Profile.
-func (p Profile) Convert(c Color) Color {
-	if p == Ascii {
-		return NoColor{}
-	}
-
-	switch v := c.(type) {
-	case ANSIColor:
-		return v
-
-	case ANSI256Color:
-		if p == ANSI {
-			return ansi256ToANSIColor(v)
-		}
-		return v
-
-	case RGBColor:
-		h, err := colorful.Hex(string(v))
-		if err != nil {
-			return nil
-		}
-		if p < TrueColor {
-			ac := hexToANSI256Color(h)
-			if p == ANSI {
-				return ansi256ToANSIColor(ac)
-			}
-			return ac
-		}
-		return v
-	}
-
-	return c
-}
-
-// Color creates a Color from a string. Valid inputs are hex colors, as well as
-// ANSI color codes (0-15, 16-255).
-func (p Profile) Color(s string) Color {
-	if len(s) == 0 {
-		return nil
-	}
-
-	var c Color
-	if strings.HasPrefix(s, "#") {
-		c = RGBColor(s)
-	} else {
-		i, err := strconv.Atoi(s)
-		if err != nil {
-			return nil
-		}
-
-		if i < 16 {
-			c = ANSIColor(i)
-		} else {
-			c = ANSI256Color(i)
-		}
-	}
-
-	return p.Convert(c)
-}
-
-// FromColor creates a Color from a color.Color.
-func (p Profile) FromColor(c color.Color) Color {
-	col, _ := colorful.MakeColor(c)
-	return p.Color(col.Hex())
 }
 
 // Sequence returns the ANSI Sequence for the color.

--- a/output.go
+++ b/output.go
@@ -27,6 +27,15 @@ func NewOutputWithProfile(tty *os.File, profile Profile) *Output {
 	}
 }
 
+// NewOutputWithProfileEnv returns a new Output for the given file descriptor and
+// autodetects the profile based on provided TERM and COLORTERM variables.
+func NewOutputWithProfileEnv(tty *os.File, term, colorTerm string) *Output {
+	return &Output{
+		Profile: colorProfile(term, colorTerm),
+		tty:     tty,
+	}
+}
+
 // ForegroundColor returns the terminal's default foreground color.
 func (o Output) ForegroundColor() Color {
 	if !isTTY(o.tty.Fd()) {

--- a/output.go
+++ b/output.go
@@ -1,0 +1,53 @@
+package termenv
+
+import "os"
+
+// Output is a terminal output.
+type Output struct {
+	Profile
+	tty *os.File
+}
+
+// NewOutput returns a new Output for the given file descriptor.
+func NewOutput(tty *os.File) *Output {
+	p := Ascii
+	if isTTY(tty.Fd()) {
+		p = envColorProfile()
+	}
+
+	return NewOutputWithProfile(tty, p)
+}
+
+// NewOutputWithProfile returns a new Output for the given file descriptor and
+// profile.
+func NewOutputWithProfile(tty *os.File, profile Profile) *Output {
+	return &Output{
+		Profile: profile,
+		tty:     tty,
+	}
+}
+
+// ForegroundColor returns the terminal's default foreground color.
+func (o Output) ForegroundColor() Color {
+	if !isTTY(o.tty.Fd()) {
+		return NoColor{}
+	}
+
+	return o.foregroundColor()
+}
+
+// BackgroundColor returns the terminal's default background color.
+func (o Output) BackgroundColor() Color {
+	if !isTTY(o.tty.Fd()) {
+		return NoColor{}
+	}
+
+	return o.backgroundColor()
+}
+
+// HasDarkBackground returns whether terminal uses a dark-ish background.
+func (o Output) HasDarkBackground() bool {
+	c := ConvertToRGB(o.BackgroundColor())
+	_, _, l := c.Hsl()
+	return l < 0.5
+}

--- a/profile.go
+++ b/profile.go
@@ -1,0 +1,97 @@
+package termenv
+
+import (
+	"image/color"
+	"strconv"
+	"strings"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+// Profile is a color profile: Ascii, ANSI, ANSI256, or TrueColor.
+type Profile int
+
+const (
+	// Ascii, uncolored profile.
+	Ascii = Profile(iota) //nolint:revive
+	// ANSI, 4-bit color profile
+	ANSI
+	// ANSI256, 8-bit color profile
+	ANSI256
+	// TrueColor, 24-bit color profile
+	TrueColor
+)
+
+// String returns a new Style.
+func (p Profile) String(s ...string) Style {
+	return Style{
+		Profile: p,
+		string:  strings.Join(s, " "),
+	}
+}
+
+// Convert transforms a given Color to a Color supported within the Profile.
+func (p Profile) Convert(c Color) Color {
+	if p == Ascii {
+		return NoColor{}
+	}
+
+	switch v := c.(type) {
+	case ANSIColor:
+		return v
+
+	case ANSI256Color:
+		if p == ANSI {
+			return ansi256ToANSIColor(v)
+		}
+		return v
+
+	case RGBColor:
+		h, err := colorful.Hex(string(v))
+		if err != nil {
+			return nil
+		}
+		if p < TrueColor {
+			ac := hexToANSI256Color(h)
+			if p == ANSI {
+				return ansi256ToANSIColor(ac)
+			}
+			return ac
+		}
+		return v
+	}
+
+	return c
+}
+
+// Color creates a Color from a string. Valid inputs are hex colors, as well as
+// ANSI color codes (0-15, 16-255).
+func (p Profile) Color(s string) Color {
+	if len(s) == 0 {
+		return nil
+	}
+
+	var c Color
+	if strings.HasPrefix(s, "#") {
+		c = RGBColor(s)
+	} else {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return nil
+		}
+
+		if i < 16 {
+			c = ANSIColor(i)
+		} else {
+			c = ANSI256Color(i)
+		}
+	}
+
+	return p.Convert(c)
+}
+
+// FromColor creates a Color from a color.Color.
+func (p Profile) FromColor(c color.Color) Color {
+	col, _ := colorful.MakeColor(c)
+	return p.Color(col.Hex())
+}

--- a/screen.go
+++ b/screen.go
@@ -2,6 +2,7 @@ package termenv
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -59,200 +60,398 @@ const (
 )
 
 // Reset the terminal to its default style, removing any active styles.
+func (o Output) Reset() {
+	fmt.Fprint(o.tty, CSI+ResetSeq+"m")
+}
+
+// SetForegroundColor sets the default foreground color.
+func (o Output) SetForegroundColor(color Color) {
+	fmt.Fprintf(o.tty, OSC+SetForegroundColorSeq, color)
+}
+
+// SetBackgroundColor sets the default background color.
+func (o Output) SetBackgroundColor(color Color) {
+	fmt.Fprintf(o.tty, OSC+SetBackgroundColorSeq, color)
+}
+
+// SetCursorColor sets the cursor color.
+func (o Output) SetCursorColor(color Color) {
+	fmt.Fprintf(o.tty, OSC+SetCursorColorSeq, color)
+}
+
+// RestoreScreen restores a previously saved screen state.
+func (o Output) RestoreScreen() {
+	fmt.Fprint(o.tty, CSI+RestoreScreenSeq)
+}
+
+// SaveScreen saves the screen state.
+func (o Output) SaveScreen() {
+	fmt.Fprint(o.tty, CSI+SaveScreenSeq)
+}
+
+// AltScreen switches to the alternate screen buffer. The former view can be
+// restored with ExitAltScreen().
+func (o Output) AltScreen() {
+	fmt.Fprint(o.tty, CSI+AltScreenSeq)
+}
+
+// ExitAltScreen exits the alternate screen buffer and returns to the former
+// terminal view.
+func (o Output) ExitAltScreen() {
+	fmt.Fprint(o.tty, CSI+ExitAltScreenSeq)
+}
+
+// ClearScreen clears the visible portion of the terminal.
+func (o Output) ClearScreen() {
+	fmt.Fprintf(o.tty, CSI+EraseDisplaySeq, 2)
+	o.MoveCursor(1, 1)
+}
+
+// MoveCursor moves the cursor to a given position.
+func (o Output) MoveCursor(row int, column int) {
+	fmt.Fprintf(o.tty, CSI+CursorPositionSeq, row, column)
+}
+
+// HideCursor hides the cursor.
+func (o Output) HideCursor() {
+	fmt.Fprintf(o.tty, CSI+HideCursorSeq)
+}
+
+// ShowCursor shows the cursor.
+func (o Output) ShowCursor() {
+	fmt.Fprintf(o.tty, CSI+ShowCursorSeq)
+}
+
+// SaveCursorPosition saves the cursor position.
+func (o Output) SaveCursorPosition() {
+	fmt.Fprint(o.tty, CSI+SaveCursorPositionSeq)
+}
+
+// RestoreCursorPosition restores a saved cursor position.
+func (o Output) RestoreCursorPosition() {
+	fmt.Fprint(o.tty, CSI+RestoreCursorPositionSeq)
+}
+
+// CursorUp moves the cursor up a given number of lines.
+func (o Output) CursorUp(n int) {
+	fmt.Fprintf(o.tty, CSI+CursorUpSeq, n)
+}
+
+// CursorDown moves the cursor down a given number of lines.
+func (o Output) CursorDown(n int) {
+	fmt.Fprintf(o.tty, CSI+CursorDownSeq, n)
+}
+
+// CursorForward moves the cursor up a given number of lines.
+func (o Output) CursorForward(n int) {
+	fmt.Fprintf(o.tty, CSI+CursorForwardSeq, n)
+}
+
+// CursorBack moves the cursor backwards a given number of cells.
+func (o Output) CursorBack(n int) {
+	fmt.Fprintf(o.tty, CSI+CursorBackSeq, n)
+}
+
+// CursorNextLine moves the cursor down a given number of lines and places it at
+// the beginning of the line.
+func (o Output) CursorNextLine(n int) {
+	fmt.Fprintf(o.tty, CSI+CursorNextLineSeq, n)
+}
+
+// CursorPrevLine moves the cursor up a given number of lines and places it at
+// the beginning of the line.
+func (o Output) CursorPrevLine(n int) {
+	fmt.Fprintf(o.tty, CSI+CursorPreviousLineSeq, n)
+}
+
+// ClearLine clears the current line.
+func (o Output) ClearLine() {
+	fmt.Fprint(o.tty, CSI+EraseEntireLineSeq)
+}
+
+// ClearLineLeft clears the line to the left of the cursor.
+func (o Output) ClearLineLeft() {
+	fmt.Fprint(o.tty, CSI+EraseLineLeftSeq)
+}
+
+// ClearLineRight clears the line to the right of the cursor.
+func (o Output) ClearLineRight() {
+	fmt.Fprint(o.tty, CSI+EraseLineRightSeq)
+}
+
+// ClearLines clears a given number of lines.
+func (o Output) ClearLines(n int) {
+	clearLine := fmt.Sprintf(CSI+EraseLineSeq, 2)
+	cursorUp := fmt.Sprintf(CSI+CursorUpSeq, 1)
+	fmt.Fprint(o.tty, clearLine+strings.Repeat(cursorUp+clearLine, n))
+}
+
+// ChangeScrollingRegion sets the scrolling region of the terminal.
+func (o Output) ChangeScrollingRegion(top, bottom int) {
+	fmt.Fprintf(o.tty, CSI+ChangeScrollingRegionSeq, top, bottom)
+}
+
+// InsertLines inserts the given number of lines at the top of the scrollable
+// region, pushing lines below down.
+func (o Output) InsertLines(n int) {
+	fmt.Fprintf(o.tty, CSI+InsertLineSeq, n)
+}
+
+// DeleteLines deletes the given number of lines, pulling any lines in
+// the scrollable region below up.
+func (o Output) DeleteLines(n int) {
+	fmt.Fprintf(o.tty, CSI+DeleteLineSeq, n)
+}
+
+// EnableMousePress enables X10 mouse mode. Button press events are sent only.
+func (o Output) EnableMousePress() {
+	fmt.Fprint(o.tty, CSI+EnableMousePressSeq)
+}
+
+// DisableMousePress disables X10 mouse mode.
+func (o Output) DisableMousePress() {
+	fmt.Fprint(o.tty, CSI+DisableMousePressSeq)
+}
+
+// EnableMouse enables Mouse Tracking mode.
+func (o Output) EnableMouse() {
+	fmt.Fprint(o.tty, CSI+EnableMouseSeq)
+}
+
+// DisableMouse disables Mouse Tracking mode.
+func (o Output) DisableMouse() {
+	fmt.Fprint(o.tty, CSI+DisableMouseSeq)
+}
+
+// EnableMouseHilite enables Hilite Mouse Tracking mode.
+func (o Output) EnableMouseHilite() {
+	fmt.Fprint(o.tty, CSI+EnableMouseHiliteSeq)
+}
+
+// DisableMouseHilite disables Hilite Mouse Tracking mode.
+func (o Output) DisableMouseHilite() {
+	fmt.Fprint(o.tty, CSI+DisableMouseHiliteSeq)
+}
+
+// EnableMouseCellMotion enables Cell Motion Mouse Tracking mode.
+func (o Output) EnableMouseCellMotion() {
+	fmt.Fprint(o.tty, CSI+EnableMouseCellMotionSeq)
+}
+
+// DisableMouseCellMotion disables Cell Motion Mouse Tracking mode.
+func (o Output) DisableMouseCellMotion() {
+	fmt.Fprint(o.tty, CSI+DisableMouseCellMotionSeq)
+}
+
+// EnableMouseAllMotion enables All Motion Mouse mode.
+func (o Output) EnableMouseAllMotion() {
+	fmt.Fprint(o.tty, CSI+EnableMouseAllMotionSeq)
+}
+
+// DisableMouseAllMotion disables All Motion Mouse mode.
+func (o Output) DisableMouseAllMotion() {
+	fmt.Fprint(o.tty, CSI+DisableMouseAllMotionSeq)
+}
+
+// SetWindowTitle sets the terminal window title.
+func (o Output) SetWindowTitle(title string) {
+	fmt.Fprintf(o.tty, OSC+SetWindowTitleSeq, title)
+}
+
+// Legacy functions.
+
+// Reset the terminal to its default style, removing any active styles.
 func Reset() {
-	fmt.Print(CSI + ResetSeq + "m")
+	NewOutputWithProfile(os.Stdout, ANSI).Reset()
 }
 
 // SetForegroundColor sets the default foreground color.
 func SetForegroundColor(color Color) {
-	fmt.Printf(OSC+SetForegroundColorSeq, color)
+	NewOutputWithProfile(os.Stdout, ANSI).SetForegroundColor(color)
 }
 
 // SetBackgroundColor sets the default background color.
 func SetBackgroundColor(color Color) {
-	fmt.Printf(OSC+SetBackgroundColorSeq, color)
+	NewOutputWithProfile(os.Stdout, ANSI).SetBackgroundColor(color)
 }
 
 // SetCursorColor sets the cursor color.
 func SetCursorColor(color Color) {
-	fmt.Printf(OSC+SetCursorColorSeq, color)
+	NewOutputWithProfile(os.Stdout, ANSI).SetCursorColor(color)
 }
 
 // RestoreScreen restores a previously saved screen state.
 func RestoreScreen() {
-	fmt.Print(CSI + RestoreScreenSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).RestoreScreen()
 }
 
 // SaveScreen saves the screen state.
 func SaveScreen() {
-	fmt.Print(CSI + SaveScreenSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).SaveScreen()
 }
 
 // AltScreen switches to the alternate screen buffer. The former view can be
 // restored with ExitAltScreen().
 func AltScreen() {
-	fmt.Print(CSI + AltScreenSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).AltScreen()
 }
 
 // ExitAltScreen exits the alternate screen buffer and returns to the former
 // terminal view.
 func ExitAltScreen() {
-	fmt.Print(CSI + ExitAltScreenSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).ExitAltScreen()
 }
 
 // ClearScreen clears the visible portion of the terminal.
 func ClearScreen() {
-	fmt.Printf(CSI+EraseDisplaySeq, 2)
-	MoveCursor(1, 1)
+	NewOutputWithProfile(os.Stdout, ANSI).ClearScreen()
 }
 
 // MoveCursor moves the cursor to a given position.
 func MoveCursor(row int, column int) {
-	fmt.Printf(CSI+CursorPositionSeq, row, column)
+	NewOutputWithProfile(os.Stdout, ANSI).MoveCursor(row, column)
 }
 
 // HideCursor hides the cursor.
 func HideCursor() {
-	fmt.Printf(CSI + HideCursorSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).HideCursor()
 }
 
 // ShowCursor shows the cursor.
 func ShowCursor() {
-	fmt.Printf(CSI + ShowCursorSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).ShowCursor()
 }
 
 // SaveCursorPosition saves the cursor position.
 func SaveCursorPosition() {
-	fmt.Print(CSI + SaveCursorPositionSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).SaveCursorPosition()
 }
 
 // RestoreCursorPosition restores a saved cursor position.
 func RestoreCursorPosition() {
-	fmt.Print(CSI + RestoreCursorPositionSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).RestoreCursorPosition()
 }
 
 // CursorUp moves the cursor up a given number of lines.
 func CursorUp(n int) {
-	fmt.Printf(CSI+CursorUpSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).CursorUp(n)
 }
 
 // CursorDown moves the cursor down a given number of lines.
 func CursorDown(n int) {
-	fmt.Printf(CSI+CursorDownSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).CursorDown(n)
 }
 
 // CursorForward moves the cursor up a given number of lines.
 func CursorForward(n int) {
-	fmt.Printf(CSI+CursorForwardSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).CursorForward(n)
 }
 
 // CursorBack moves the cursor backwards a given number of cells.
 func CursorBack(n int) {
-	fmt.Printf(CSI+CursorBackSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).CursorBack(n)
 }
 
 // CursorNextLine moves the cursor down a given number of lines and places it at
 // the beginning of the line.
 func CursorNextLine(n int) {
-	fmt.Printf(CSI+CursorNextLineSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).CursorNextLine(n)
 }
 
 // CursorPrevLine moves the cursor up a given number of lines and places it at
 // the beginning of the line.
 func CursorPrevLine(n int) {
-	fmt.Printf(CSI+CursorPreviousLineSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).CursorPrevLine(n)
 }
 
 // ClearLine clears the current line.
 func ClearLine() {
-	fmt.Print(CSI + EraseEntireLineSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).ClearLine()
 }
 
 // ClearLineLeft clears the line to the left of the cursor.
 func ClearLineLeft() {
-	fmt.Print(CSI + EraseLineLeftSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).ClearLineLeft()
 }
 
 // ClearLineRight clears the line to the right of the cursor.
 func ClearLineRight() {
-	fmt.Print(CSI + EraseLineRightSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).ClearLineRight()
 }
 
 // ClearLines clears a given number of lines.
 func ClearLines(n int) {
-	clearLine := fmt.Sprintf(CSI+EraseLineSeq, 2)
-	cursorUp := fmt.Sprintf(CSI+CursorUpSeq, 1)
-	fmt.Print(clearLine + strings.Repeat(cursorUp+clearLine, n))
+	NewOutputWithProfile(os.Stdout, ANSI).ClearLines(n)
 }
 
 // ChangeScrollingRegion sets the scrolling region of the terminal.
 func ChangeScrollingRegion(top, bottom int) {
-	fmt.Printf(CSI+ChangeScrollingRegionSeq, top, bottom)
+	NewOutputWithProfile(os.Stdout, ANSI).ChangeScrollingRegion(top, bottom)
 }
 
 // InsertLines inserts the given number of lines at the top of the scrollable
 // region, pushing lines below down.
 func InsertLines(n int) {
-	fmt.Printf(CSI+InsertLineSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).InsertLines(n)
 }
 
 // DeleteLines deletes the given number of lines, pulling any lines in
 // the scrollable region below up.
 func DeleteLines(n int) {
-	fmt.Printf(CSI+DeleteLineSeq, n)
+	NewOutputWithProfile(os.Stdout, ANSI).DeleteLines(n)
 }
 
 // EnableMousePress enables X10 mouse mode. Button press events are sent only.
 func EnableMousePress() {
-	fmt.Print(CSI + EnableMousePressSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).EnableMousePress()
 }
 
 // DisableMousePress disables X10 mouse mode.
 func DisableMousePress() {
-	fmt.Print(CSI + EnableMousePressSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).DisableMousePress()
 }
 
 // EnableMouse enables Mouse Tracking mode.
 func EnableMouse() {
-	fmt.Print(CSI + EnableMouseSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).EnableMouse()
 }
 
 // DisableMouse disables Mouse Tracking mode.
 func DisableMouse() {
-	fmt.Print(CSI + DisableMouseSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).DisableMouse()
 }
 
 // EnableMouseHilite enables Hilite Mouse Tracking mode.
 func EnableMouseHilite() {
-	fmt.Print(CSI + EnableMouseHiliteSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).EnableMouseHilite()
 }
 
 // DisableMouseHilite disables Hilite Mouse Tracking mode.
 func DisableMouseHilite() {
-	fmt.Print(CSI + DisableMouseHiliteSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).DisableMouseHilite()
 }
 
 // EnableMouseCellMotion enables Cell Motion Mouse Tracking mode.
 func EnableMouseCellMotion() {
-	fmt.Print(CSI + EnableMouseCellMotionSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).EnableMouseCellMotion()
 }
 
 // DisableMouseCellMotion disables Cell Motion Mouse Tracking mode.
 func DisableMouseCellMotion() {
-	fmt.Print(CSI + DisableMouseCellMotionSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).DisableMouseCellMotion()
 }
 
 // EnableMouseAllMotion enables All Motion Mouse mode.
 func EnableMouseAllMotion() {
-	fmt.Print(CSI + EnableMouseAllMotionSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).EnableMouseAllMotion()
 }
 
 // DisableMouseAllMotion disables All Motion Mouse mode.
 func DisableMouseAllMotion() {
-	fmt.Print(CSI + DisableMouseAllMotionSeq)
+	NewOutputWithProfile(os.Stdout, ANSI).DisableMouseAllMotion()
 }
 
 // SetWindowTitle sets the terminal window title.
 func SetWindowTitle(title string) {
-	fmt.Printf(OSC+SetWindowTitleSeq, title)
+	NewOutputWithProfile(os.Stdout, ANSI).SetWindowTitle(title)
 }

--- a/screen_test.go
+++ b/screen_test.go
@@ -1,0 +1,269 @@
+package termenv
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func tempOutput(t *testing.T) *Output {
+	t.Helper()
+
+	f, err := ioutil.TempFile("", "termenv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return NewOutputWithProfile(f, TrueColor)
+}
+
+func verify(t *testing.T, o *Output, exp string) {
+	t.Helper()
+
+	if _, err := o.tty.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := ioutil.ReadAll(o.tty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != exp {
+		b = bytes.Replace(b, []byte("\x1b"), []byte("\\x1b"), -1)
+		exp = strings.Replace(exp, "\x1b", "\\x1b", -1)
+		t.Errorf("output does not match, expected %s, got %s", exp, string(b))
+	}
+
+	// remove temp file
+	os.Remove(o.tty.Name())
+}
+
+func TestReset(t *testing.T) {
+	o := tempOutput(t)
+	o.Reset()
+	verify(t, o, "\x1b[0m")
+}
+
+func TestSetForegroundColor(t *testing.T) {
+	o := tempOutput(t)
+	o.SetForegroundColor(ANSI.Color("0"))
+	verify(t, o, "\x1b]10;#000000\a")
+}
+
+func TestSetBackgroundColor(t *testing.T) {
+	o := tempOutput(t)
+	o.SetBackgroundColor(ANSI.Color("0"))
+	verify(t, o, "\x1b]11;#000000\a")
+}
+
+func TestSetCursorColor(t *testing.T) {
+	o := tempOutput(t)
+	o.SetCursorColor(ANSI.Color("0"))
+	verify(t, o, "\x1b]12;#000000\a")
+}
+
+func TestRestoreScreen(t *testing.T) {
+	o := tempOutput(t)
+	o.RestoreScreen()
+	verify(t, o, "\x1b[?47l")
+}
+
+func TestSaveScreen(t *testing.T) {
+	o := tempOutput(t)
+	o.SaveScreen()
+	verify(t, o, "\x1b[?47h")
+}
+
+func TestAltScreen(t *testing.T) {
+	o := tempOutput(t)
+	o.AltScreen()
+	verify(t, o, "\x1b[?1049h")
+}
+
+func TestExitAltScreen(t *testing.T) {
+	o := tempOutput(t)
+	o.ExitAltScreen()
+	verify(t, o, "\x1b[?1049l")
+}
+
+func TestClearScreen(t *testing.T) {
+	o := tempOutput(t)
+	o.ClearScreen()
+	verify(t, o, "\x1b[2J\x1b[1;1H")
+}
+
+func TestMoveCursor(t *testing.T) {
+	o := tempOutput(t)
+	o.MoveCursor(16, 8)
+	verify(t, o, "\x1b[16;8H")
+}
+
+func TestHideCursor(t *testing.T) {
+	o := tempOutput(t)
+	o.HideCursor()
+	verify(t, o, "\x1b[?25l")
+}
+
+func TestShowCursor(t *testing.T) {
+	o := tempOutput(t)
+	o.ShowCursor()
+	verify(t, o, "\x1b[?25h")
+}
+
+func TestSaveCursorPosition(t *testing.T) {
+	o := tempOutput(t)
+	o.SaveCursorPosition()
+	verify(t, o, "\x1b[s")
+}
+
+func TestRestoreCursorPosition(t *testing.T) {
+	o := tempOutput(t)
+	o.RestoreCursorPosition()
+	verify(t, o, "\x1b[u")
+}
+
+func TestCursorUp(t *testing.T) {
+	o := tempOutput(t)
+	o.CursorUp(8)
+	verify(t, o, "\x1b[8A")
+}
+
+func TestCursorDown(t *testing.T) {
+	o := tempOutput(t)
+	o.CursorDown(8)
+	verify(t, o, "\x1b[8B")
+}
+
+func TestCursorForward(t *testing.T) {
+	o := tempOutput(t)
+	o.CursorForward(8)
+	verify(t, o, "\x1b[8C")
+}
+
+func TestCursorBack(t *testing.T) {
+	o := tempOutput(t)
+	o.CursorBack(8)
+	verify(t, o, "\x1b[8D")
+}
+
+func TestCursorNextLine(t *testing.T) {
+	o := tempOutput(t)
+	o.CursorNextLine(8)
+	verify(t, o, "\x1b[8E")
+}
+
+func TestCursorPrevLine(t *testing.T) {
+	o := tempOutput(t)
+	o.CursorPrevLine(8)
+	verify(t, o, "\x1b[8F")
+}
+
+func TestClearLine(t *testing.T) {
+	o := tempOutput(t)
+	o.ClearLine()
+	verify(t, o, "\x1b[2K")
+}
+
+func TestClearLineLeft(t *testing.T) {
+	o := tempOutput(t)
+	o.ClearLineLeft()
+	verify(t, o, "\x1b[1K")
+}
+
+func TestClearLineRight(t *testing.T) {
+	o := tempOutput(t)
+	o.ClearLineRight()
+	verify(t, o, "\x1b[0K")
+}
+
+func TestClearLines(t *testing.T) {
+	o := tempOutput(t)
+	o.ClearLines(8)
+	verify(t, o, "\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K")
+}
+
+func TestChangeScrollingRegion(t *testing.T) {
+	o := tempOutput(t)
+	o.ChangeScrollingRegion(16, 8)
+	verify(t, o, "\x1b[16;8r")
+}
+
+func TestInsertLines(t *testing.T) {
+	o := tempOutput(t)
+	o.InsertLines(8)
+	verify(t, o, "\x1b[8L")
+}
+
+func TestDeleteLines(t *testing.T) {
+	o := tempOutput(t)
+	o.DeleteLines(8)
+	verify(t, o, "\x1b[8M")
+}
+
+func TestEnableMousePress(t *testing.T) {
+	o := tempOutput(t)
+	o.EnableMousePress()
+	verify(t, o, "\x1b[?9h")
+}
+
+func TestDisableMousePress(t *testing.T) {
+	o := tempOutput(t)
+	o.DisableMousePress()
+	verify(t, o, "\x1b[?9l")
+}
+
+func TestEnableMouse(t *testing.T) {
+	o := tempOutput(t)
+	o.EnableMouse()
+	verify(t, o, "\x1b[?1000h")
+}
+
+func TestDisableMouse(t *testing.T) {
+	o := tempOutput(t)
+	o.DisableMouse()
+	verify(t, o, "\x1b[?1000l")
+}
+
+func TestEnableMouseHilite(t *testing.T) {
+	o := tempOutput(t)
+	o.EnableMouseHilite()
+	verify(t, o, "\x1b[?1001h")
+}
+
+func TestDisableMouseHilite(t *testing.T) {
+	o := tempOutput(t)
+	o.DisableMouseHilite()
+	verify(t, o, "\x1b[?1001l")
+}
+
+func TestEnableMouseCellMotion(t *testing.T) {
+	o := tempOutput(t)
+	o.EnableMouseCellMotion()
+	verify(t, o, "\x1b[?1002h")
+}
+
+func TestDisableMouseCellMotion(t *testing.T) {
+	o := tempOutput(t)
+	o.DisableMouseCellMotion()
+	verify(t, o, "\x1b[?1002l")
+}
+
+func TestEnableMouseAllMotion(t *testing.T) {
+	o := tempOutput(t)
+	o.EnableMouseAllMotion()
+	verify(t, o, "\x1b[?1003h")
+}
+
+func TestDisableMouseAllMotion(t *testing.T) {
+	o := tempOutput(t)
+	o.DisableMouseAllMotion()
+	verify(t, o, "\x1b[?1003l")
+}
+
+func TestSetWindowTitle(t *testing.T) {
+	o := tempOutput(t)
+	o.SetWindowTitle("test")
+	verify(t, o, "\x1b]2;test\a")
+}

--- a/style.go
+++ b/style.go
@@ -22,6 +22,7 @@ const (
 
 // Style is a string that various rendering styles can be applied to.
 type Style struct {
+	Profile Profile
 	string
 	styles []string
 }
@@ -29,7 +30,8 @@ type Style struct {
 // String returns a new Style.
 func String(s ...string) Style {
 	return Style{
-		string: strings.Join(s, " "),
+		Profile: TrueColor,
+		string:  strings.Join(s, " "),
 	}
 }
 
@@ -39,6 +41,9 @@ func (t Style) String() string {
 
 // Styled renders s with all applied styles.
 func (t Style) Styled(s string) string {
+	if t.Profile == Ascii {
+		return s
+	}
 	if len(t.styles) == 0 {
 		return s
 	}

--- a/templatehelper.go
+++ b/templatehelper.go
@@ -8,7 +8,7 @@ import (
 func TemplateFuncs(p Profile) template.FuncMap {
 	return template.FuncMap{
 		"Color": func(values ...interface{}) string {
-			s := String(values[len(values)-1].(string))
+			s := p.String(values[len(values)-1].(string))
 			switch len(values) {
 			case 2:
 				s = s.Foreground(p.Color(values[0].(string)))
@@ -21,7 +21,7 @@ func TemplateFuncs(p Profile) template.FuncMap {
 			return s.String()
 		},
 		"Foreground": func(values ...interface{}) string {
-			s := String(values[len(values)-1].(string))
+			s := p.String(values[len(values)-1].(string))
 			if len(values) == 2 {
 				s = s.Foreground(p.Color(values[0].(string)))
 			}
@@ -29,27 +29,27 @@ func TemplateFuncs(p Profile) template.FuncMap {
 			return s.String()
 		},
 		"Background": func(values ...interface{}) string {
-			s := String(values[len(values)-1].(string))
+			s := p.String(values[len(values)-1].(string))
 			if len(values) == 2 {
 				s = s.Background(p.Color(values[0].(string)))
 			}
 
 			return s.String()
 		},
-		"Bold":      styleFunc(Style.Bold),
-		"Faint":     styleFunc(Style.Faint),
-		"Italic":    styleFunc(Style.Italic),
-		"Underline": styleFunc(Style.Underline),
-		"Overline":  styleFunc(Style.Overline),
-		"Blink":     styleFunc(Style.Blink),
-		"Reverse":   styleFunc(Style.Reverse),
-		"CrossOut":  styleFunc(Style.CrossOut),
+		"Bold":      styleFunc(p, Style.Bold),
+		"Faint":     styleFunc(p, Style.Faint),
+		"Italic":    styleFunc(p, Style.Italic),
+		"Underline": styleFunc(p, Style.Underline),
+		"Overline":  styleFunc(p, Style.Overline),
+		"Blink":     styleFunc(p, Style.Blink),
+		"Reverse":   styleFunc(p, Style.Reverse),
+		"CrossOut":  styleFunc(p, Style.CrossOut),
 	}
 }
 
-func styleFunc(f func(Style) Style) func(...interface{}) string {
+func styleFunc(p Profile, f func(Style) Style) func(...interface{}) string {
 	return func(values ...interface{}) string {
-		s := String(values[0].(string))
+		s := p.String(values[0].(string))
 		return f(s).String()
 	}
 }

--- a/termenv.go
+++ b/termenv.go
@@ -40,13 +40,13 @@ func ColorProfile() Profile {
 // ForegroundColor returns the terminal's default foreground color.
 func ForegroundColor() Color {
 	o := NewOutputWithProfile(os.Stdout, TrueColor)
-	return o.foregroundColor()
+	return o.ForegroundColor()
 }
 
 // BackgroundColor returns the terminal's default background color.
 func BackgroundColor() Color {
 	o := NewOutputWithProfile(os.Stdout, TrueColor)
-	return o.backgroundColor()
+	return o.BackgroundColor()
 }
 
 // HasDarkBackground returns whether terminal uses a dark-ish background.

--- a/termenv.go
+++ b/termenv.go
@@ -12,23 +12,11 @@ var (
 	ErrStatusReport = errors.New("unable to retrieve status report")
 )
 
-// Profile is a color profile: Ascii, ANSI, ANSI256, or TrueColor.
-type Profile int
-
 const (
 	// Control Sequence Introducer
 	CSI = "\x1b["
 	// Operating System Command
 	OSC = "\x1b]"
-
-	// Ascii, uncolored profile.
-	Ascii = Profile(iota) //nolint:revive
-	// ANSI, 4-bit color profile
-	ANSI
-	// ANSI256, 8-bit color profile
-	ANSI256
-	// TrueColor, 24-bit color profile
-	TrueColor
 )
 
 func isTTY(fd uintptr) bool {

--- a/termenv.go
+++ b/termenv.go
@@ -51,27 +51,20 @@ func ColorProfile() Profile {
 
 // ForegroundColor returns the terminal's default foreground color.
 func ForegroundColor() Color {
-	if !isTTY(os.Stdout.Fd()) {
-		return NoColor{}
-	}
-
-	return foregroundColor()
+	o := NewOutputWithProfile(os.Stdout, TrueColor)
+	return o.foregroundColor()
 }
 
 // BackgroundColor returns the terminal's default background color.
 func BackgroundColor() Color {
-	if !isTTY(os.Stdout.Fd()) {
-		return NoColor{}
-	}
-
-	return backgroundColor()
+	o := NewOutputWithProfile(os.Stdout, TrueColor)
+	return o.backgroundColor()
 }
 
 // HasDarkBackground returns whether terminal uses a dark-ish background.
 func HasDarkBackground() bool {
-	c := ConvertToRGB(BackgroundColor())
-	_, _, l := c.Hsl()
-	return l < 0.5
+	o := NewOutputWithProfile(os.Stdout, TrueColor)
+	return o.HasDarkBackground()
 }
 
 // EnvNoColor returns true if the environment variables explicitly disable color output
@@ -95,6 +88,17 @@ func EnvColorProfile() Profile {
 		return Ascii
 	}
 	p := ColorProfile()
+	if cliColorForced() && p == Ascii {
+		return ANSI
+	}
+	return p
+}
+
+func envColorProfile() Profile {
+	if EnvNoColor() {
+		return Ascii
+	}
+	p := colorProfile()
 	if cliColorForced() && p == Ascii {
 		return ANSI
 	}

--- a/termenv.go
+++ b/termenv.go
@@ -34,7 +34,9 @@ func ColorProfile() Profile {
 		return Ascii
 	}
 
-	return colorProfile()
+	term := os.Getenv("TERM")
+	colorTerm := os.Getenv("COLORTERM")
+	return colorProfile(term, colorTerm)
 }
 
 // ForegroundColor returns the terminal's default foreground color.
@@ -86,7 +88,9 @@ func envColorProfile() Profile {
 	if EnvNoColor() {
 		return Ascii
 	}
-	p := colorProfile()
+	term := os.Getenv("TERM")
+	colorTerm := os.Getenv("COLORTERM")
+	p := colorProfile(term, colorTerm)
 	if cliColorForced() && p == Ascii {
 		return ANSI
 	}

--- a/termenv_js.go
+++ b/termenv_js.go
@@ -7,12 +7,12 @@ func colorProfile() Profile {
 	return ANSI256
 }
 
-func foregroundColor() Color {
+func (o Output) foregroundColor() Color {
 	// default gray
 	return ANSIColor(7)
 }
 
-func backgroundColor() Color {
+func (o Output) backgroundColor() Color {
 	// default black
 	return ANSIColor(0)
 }

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -3,15 +3,38 @@ package termenv
 import (
 	"bytes"
 	"fmt"
+	"image/color"
 	"os"
 	"strings"
 	"testing"
 	"text/template"
 )
 
+func TestLegacyTermEnv(t *testing.T) {
+	p := ColorProfile()
+	if p != TrueColor && p != Ascii {
+		t.Errorf("Expected %d, got %d", TrueColor, p)
+	}
+
+	fg := ForegroundColor()
+	fgseq := fg.Sequence(false)
+	fgexp := "97"
+	if fgseq != fgexp && fgseq != "" {
+		t.Errorf("Expected %s, got %s", fgexp, fgseq)
+	}
+
+	bg := BackgroundColor()
+	bgseq := bg.Sequence(true)
+	bgexp := "48;2;0;0;0"
+	if bgseq != bgexp && bgseq != "" {
+		t.Errorf("Expected %s, got %s", bgexp, bgseq)
+	}
+
+	_ = HasDarkBackground()
+}
+
 func TestTermEnv(t *testing.T) {
 	o := NewOutput(os.Stdout)
-	fmt.Println(o.Profile)
 	if o.Profile != TrueColor && o.Profile != Ascii {
 		t.Errorf("Expected %d, got %d", TrueColor, o.Profile)
 	}

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -3,7 +3,6 @@ package termenv
 import (
 	"bytes"
 	"fmt"
-	"image/color"
 	"os"
 	"strings"
 	"testing"
@@ -11,19 +10,20 @@ import (
 )
 
 func TestTermEnv(t *testing.T) {
-	p := ColorProfile()
-	if p != TrueColor && p != Ascii {
-		t.Errorf("Expected %d, got %d", TrueColor, p)
+	o := NewOutput(os.Stdout)
+	fmt.Println(o.Profile)
+	if o.Profile != TrueColor && o.Profile != Ascii {
+		t.Errorf("Expected %d, got %d", TrueColor, o.Profile)
 	}
 
-	fg := ForegroundColor()
+	fg := o.ForegroundColor()
 	fgseq := fg.Sequence(false)
 	fgexp := "97"
 	if fgseq != fgexp && fgseq != "" {
 		t.Errorf("Expected %s, got %s", fgexp, fgseq)
 	}
 
-	bg := BackgroundColor()
+	bg := o.BackgroundColor()
 	bgseq := bg.Sequence(true)
 	bgexp := "48;2;0;0;0"
 	if bgseq != bgexp && bgseq != "" {

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -27,9 +27,7 @@ func isForeground(fd int) bool {
 	return pgrp == unix.Getpgrp()
 }
 
-func colorProfile() Profile {
-	term := os.Getenv("TERM")
-	colorTerm := os.Getenv("COLORTERM")
+func colorProfile(term, colorTerm string) Profile {
 
 	switch strings.ToLower(colorTerm) {
 	case "24bit":

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -65,8 +65,8 @@ func colorProfile() Profile {
 	return Ascii
 }
 
-func foregroundColor() Color {
-	s, err := termStatusReport(10)
+func (o Output) foregroundColor() Color {
+	s, err := o.termStatusReport(10)
 	if err == nil {
 		c, err := xTermColor(s)
 		if err == nil {
@@ -87,8 +87,8 @@ func foregroundColor() Color {
 	return ANSIColor(7)
 }
 
-func backgroundColor() Color {
-	s, err := termStatusReport(11)
+func (o Output) backgroundColor() Color {
+	s, err := o.termStatusReport(11)
 	if err == nil {
 		c, err := xTermColor(s)
 		if err == nil {
@@ -188,7 +188,7 @@ func readNextResponse(fd *os.File) (response string, isOSC bool, err error) {
 	}
 
 	for {
-		b, err := readNextByte(os.Stdout)
+		b, err := readNextByte(fd)
 		if err != nil {
 			return "", false, err
 		}
@@ -216,7 +216,7 @@ func readNextResponse(fd *os.File) (response string, isOSC bool, err error) {
 	return "", false, ErrStatusReport
 }
 
-func termStatusReport(sequence int) (string, error) {
+func (o Output) termStatusReport(sequence int) (string, error) {
 	// screen/tmux can't support OSC, because they can be connected to multiple
 	// terminals concurrently.
 	term := os.Getenv("TERM")
@@ -224,32 +224,33 @@ func termStatusReport(sequence int) (string, error) {
 		return "", ErrStatusReport
 	}
 
+	fd := int(o.tty.Fd())
 	// if in background, we can't control the terminal
-	if !isForeground(unix.Stdout) {
+	if !isForeground(fd) {
 		return "", ErrStatusReport
 	}
 
-	t, err := unix.IoctlGetTermios(unix.Stdout, tcgetattr)
+	t, err := unix.IoctlGetTermios(fd, tcgetattr)
 	if err != nil {
 		return "", ErrStatusReport
 	}
-	defer unix.IoctlSetTermios(unix.Stdout, tcsetattr, t) //nolint:errcheck
+	defer unix.IoctlSetTermios(fd, tcsetattr, t) //nolint:errcheck
 
 	noecho := *t
 	noecho.Lflag = noecho.Lflag &^ unix.ECHO
 	noecho.Lflag = noecho.Lflag &^ unix.ICANON
-	if err := unix.IoctlSetTermios(unix.Stdout, tcsetattr, &noecho); err != nil {
+	if err := unix.IoctlSetTermios(fd, tcsetattr, &noecho); err != nil {
 		return "", ErrStatusReport
 	}
 
 	// first, send OSC query, which is ignored by terminal which do not support it
-	fmt.Printf("\033]%d;?\033\\", sequence)
+	fmt.Fprintf(o.tty, "\033]%d;?\033\\", sequence)
 
 	// then, query cursor position, should be supported by all terminals
-	fmt.Printf("\033[6n")
+	fmt.Fprintf(o.tty, "\033[6n")
 
 	// read the next response
-	res, isOSC, err := readNextResponse(os.Stdout)
+	res, isOSC, err := readNextResponse(o.tty)
 	if err != nil {
 		return "", err
 	}
@@ -260,7 +261,7 @@ func termStatusReport(sequence int) (string, error) {
 	}
 
 	// read the cursor query response next and discard the result
-	_, _, err = readNextResponse(os.Stdout)
+	_, _, err = readNextResponse(o.tty)
 	if err != nil {
 		return "", err
 	}

--- a/termenv_windows.go
+++ b/termenv_windows.go
@@ -39,12 +39,12 @@ func colorProfile() Profile {
 	return TrueColor
 }
 
-func foregroundColor() Color {
+func (o Output) foregroundColor() Color {
 	// default gray
 	return ANSIColor(7)
 }
 
-func backgroundColor() Color {
+func (o Output) backgroundColor() Color {
 	// default black
 	return ANSIColor(0)
 }


### PR DESCRIPTION
Adds ability to reuse autodetection features of termenv with arbitrary outputs based on TERM and COLORTERM.

relates to https://github.com/charmbracelet/bubbles/pull/152 and conversations in the charmbracelet slack

