### PR TITLE
Add stub Windows console functions on non-Windows platforms

### DIFF
--- a/termenv_test.go
+++ b/termenv_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image/color"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"text/template"
@@ -329,5 +330,26 @@ func TestEnvNoColor(t *testing.T) {
 				t.Errorf("expected %t but was %t", test.expected, actual)
 			}
 		})
+	}
+}
+
+func TestWindowsConsole(t *testing.T) {
+	// Test that the stub Windows console functions are present on all
+	// platforms. This test will cause a compile failure if they are not
+	// present.
+
+	// On Windows, don't run the functions as they require stdout to be a
+	// console, which is not the case in go test.
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	// On non-Windows platforms, call the functions as they don't do anything.
+	mode, err := EnableWindowsANSIConsole()
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if err := RestoreWindowsConsole(mode); err != nil {
+		t.Errorf("Expected nil, got %v", err)
 	}
 }

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -145,8 +145,8 @@ func readNextByte(f *os.File) (byte, error) {
 }
 
 // readNextResponse reads either an OSC response or a cursor position response:
-//  * OSC response: "\x1b]11;rgb:1111/1111/1111\x1b\\"
-//  * cursor position response: "\x1b[42;1R"
+//   - OSC response: "\x1b]11;rgb:1111/1111/1111\x1b\\"
+//   - cursor position response: "\x1b[42;1R"
 func readNextResponse(fd *os.File) (response string, isOSC bool, err error) {
 	start, err := readNextByte(fd)
 	if err != nil {

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -262,3 +262,13 @@ func termStatusReport(sequence int) (string, error) {
 	// fmt.Println("Rcvd", res[1:])
 	return res, nil
 }
+
+// EnableWindowsANSIConsole does nothing on non-Windows platforms.
+func EnableWindowsANSIConsole() (uint32, error) {
+	return 0, nil
+}
+
+// RestoreWindowsConsole does nothing on non-Windows platforms.
+func RestoreWindowsConsole(mode uint32) error {
+	return nil
+}


### PR DESCRIPTION
Calls to `EnableWindowsANSIConsole` are only required on Windows. Currently, the `termenv` package only *defines* these functions on Windows so build tags, i.e. multiple source files (one for Windows, one for non-Windows), are required to selectively call the function.

This PR adds stub `EnableWindowsANSIConsole` and `RestoreWindowsConsole` functions that are no-ops on non-Windows platforms. This means that the following code has the correct behavior on all platforms, without the use of build tags:

```go
if runtime.GOOS == "windows" {
    mode, err := termenv.EnableWindowsANSIConsole()
    // ...
    defer termenv.RestoreWindowsConsole(mode)
}
```

The `runtime.GOOS == "windows"` check is not strictly necessary, but makes the intent of the code clearer.