### PR TITLE
chore: use consts for sequences

### DIFF
--- a/color.go
+++ b/color.go
@@ -117,12 +117,12 @@ func xTermColor(s string) (RGBColor, error) {
 	}
 
 	switch {
-	case strings.HasSuffix(s, "\a"):
-		s = strings.TrimSuffix(s, "\a")
-	case strings.HasSuffix(s, "\033"):
-		s = strings.TrimSuffix(s, "\033")
-	case strings.HasSuffix(s, "\033\\"):
-		s = strings.TrimSuffix(s, "\033\\")
+	case strings.HasSuffix(s, string(BEL)):
+		s = strings.TrimSuffix(s, string(BEL))
+	case strings.HasSuffix(s, string(ESC)):
+		s = strings.TrimSuffix(s, string(ESC))
+	case strings.HasSuffix(s, ST):
+		s = strings.TrimSuffix(s, ST)
 	default:
 		return RGBColor(""), ErrInvalidColor
 	}

--- a/hyperlink.go
+++ b/hyperlink.go
@@ -1,9 +1,5 @@
 package termenv
 
-import (
-	"fmt"
-)
-
 // Hyperlink creates a hyperlink using OSC8.
 func Hyperlink(link, name string) string {
 	return output.Hyperlink(link, name)
@@ -11,5 +7,5 @@ func Hyperlink(link, name string) string {
 
 // Hyperlink creates a hyperlink using OSC8.
 func (o *Output) Hyperlink(link, name string) string {
-	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", link, name)
+	return OSC + "8;;" + link + ST + name + OSC + "8;;" + ST
 }

--- a/notification.go
+++ b/notification.go
@@ -1,7 +1,5 @@
 package termenv
 
-import "fmt"
-
 // Notification triggers a notification using OSC777.
 func Notification(title, body string) {
 	output.Notification(title, body)
@@ -9,5 +7,5 @@ func Notification(title, body string) {
 
 // Notification triggers a notification using OSC777.
 func (o *Output) Notification(title, body string) {
-	_, _ = o.WriteString(fmt.Sprintf(OSC+"777;notify;%s;%s\x1b\\", title, body))
+	_, _ = o.WriteString(OSC + "777;notify;" + title + ";" + body + ST)
 }

--- a/screen.go
+++ b/screen.go
@@ -57,10 +57,10 @@ const (
 	EndBracketedPasteSeq     = "201~"
 
 	// Session.
-	SetWindowTitleSeq     = "2;%s\007"
-	SetForegroundColorSeq = "10;%s\007"
-	SetBackgroundColorSeq = "11;%s\007"
-	SetCursorColorSeq     = "12;%s\007"
+	SetWindowTitleSeq     = "2;%s" + string(BEL)
+	SetForegroundColorSeq = "10;%s" + string(BEL)
+	SetBackgroundColorSeq = "11;%s" + string(BEL)
+	SetCursorColorSeq     = "12;%s" + string(BEL)
 	ShowCursorSeq         = "?25h"
 	HideCursorSeq         = "?25l"
 )

--- a/termenv.go
+++ b/termenv.go
@@ -12,10 +12,16 @@ var (
 )
 
 const (
+	// Escape character
+	ESC = '\x1b'
+	// Bell
+	BEL = '\a'
 	// Control Sequence Introducer
-	CSI = "\x1b["
+	CSI = string(ESC) + "["
 	// Operating System Command
-	OSC = "\x1b]"
+	OSC = string(ESC) + "]"
+	// String Terminator
+	ST = string(ESC) + `\`
 )
 
 func (o *Output) isTTY() bool {

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -160,7 +160,7 @@ func readNextResponse(fd File) (response string, isOSC bool, err error) {
 	}
 
 	// first byte must be ESC
-	for start != '\033' {
+	for start != ESC {
 		start, err = readNextByte(fd)
 		if err != nil {
 			return "", false, err
@@ -197,7 +197,7 @@ func readNextResponse(fd File) (response string, isOSC bool, err error) {
 
 		if oscResponse {
 			// OSC can be terminated by BEL (\a) or ST (ESC)
-			if b == '\a' || strings.HasSuffix(response, "\033") {
+			if b == BEL || strings.HasSuffix(response, string(ESC)) {
 				return response, true, nil
 			}
 		} else {
@@ -249,10 +249,10 @@ func (o Output) termStatusReport(sequence int) (string, error) {
 	}
 
 	// first, send OSC query, which is ignored by terminal which do not support it
-	fmt.Fprintf(tty, "\033]%d;?\033\\", sequence)
+	fmt.Fprintf(tty, OSC+"%d;?"+ST, sequence)
 
 	// then, query cursor position, should be supported by all terminals
-	fmt.Fprintf(tty, "\033[6n")
+	fmt.Fprintf(tty, CSI+"6n")
 
 	// read the next response
 	res, isOSC, err := readNextResponse(tty)


### PR DESCRIPTION
Reduces use of repeated string literals and `fmt.Sprintf`.