### PR TITLE
feat(mouse): add extended mouse sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,25 +313,25 @@ termenv.DisableBracketedPaste()
 <details>
 <summary>Click to show feature matrix</summary>
 
-| Terminal         | Query Color Scheme | Query Cursor Position | Set Window Title | Change Cursor Color | Change Default Foreground Setting | Change Default Background Setting | Bracketed Paste |
-| ---------------- | :----------------: | :-------------------: | :--------------: | :-----------------: | :-------------------------------: | :-------------------------------: | :-------------: |
-| alacritty        |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| foot             |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| kitty            |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| Konsole          |         ✅         |          ✅           |        ✅        |         ❌          |                ✅                 |                ✅                 |        ✅       |
-| rxvt             |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| urxvt            |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| screen           |      ⛔[^mux]      |          ✅           |        ✅        |         ❌          |                ❌                 |                ✅                 |        ❌       |
-| st               |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| tmux             |      ⛔[^mux]      |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| vte-based[^vte]  |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ❌                 |        ✅       |
-| wezterm          |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
-| xterm            |         ✅         |          ✅           |        ✅        |         ❌          |                ❌                 |                ❌                 |        ✅       |
-| Linux Console    |         ❌         |          ✅           |        ⛔        |         ❌          |                ❌                 |                ❌                 |        ❌       |
-| Apple Terminal   |         ✅         |          ✅           |        ✅        |         ❌          |                ✅                 |                ✅                 |        ✅       |
-| iTerm            |         ✅         |          ✅           |        ✅        |         ❌          |                ❌                 |                ❌                 |        ✅       |
-| Windows cmd      |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ❌       |
-| Windows Terminal |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |        ✅       |
+| Terminal         | Query Color Scheme | Query Cursor Position | Set Window Title | Change Cursor Color | Change Default Foreground Setting | Change Default Background Setting | Bracketed Paste | Extended Mouse (SGR) | Pixels Mouse (SGR-Pixels) |
+| ---------------- | :----------------: | :-------------------: | :--------------: | :-----------------: | :-------------------------------: | :-------------------------------: | :-------------: | :------------------: | :-----------------------: |
+| alacritty        |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
+| foot             |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ✅             |
+| kitty            |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ✅             |
+| Konsole          |         ✅         |          ✅           |        ✅        |         ❌          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
+| rxvt             |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ❌          |            ❌             |
+| urxvt            |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
+| screen           |      ⛔[^mux]      |          ✅           |        ✅        |         ❌          |                ❌                 |                ✅                 |       ❌        |          ❌          |            ❌             |
+| st               |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
+| tmux             |      ⛔[^mux]      |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
+| vte-based[^vte]  |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ❌                 |       ✅        |          ✅          |            ❌             |
+| wezterm          |         ✅         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ✅             |
+| xterm            |         ✅         |          ✅           |        ✅        |         ❌          |                ❌                 |                ❌                 |       ✅        |          ✅          |            ❌             |
+| Linux Console    |         ❌         |          ✅           |        ⛔        |         ❌          |                ❌                 |                ❌                 |       ❌        |          ❌          |            ❌             |
+| Apple Terminal   |         ✅         |          ✅           |        ✅        |         ❌          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
+| iTerm            |         ✅         |          ✅           |        ✅        |         ❌          |                ❌                 |                ❌                 |       ✅        |          ✅          |            ❌             |
+| Windows cmd      |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ❌        |          ❌          |            ❌             |
+| Windows Terminal |         ❌         |          ✅           |        ✅        |         ✅          |                ✅                 |                ✅                 |       ✅        |          ✅          |            ❌             |
 
 [^vte]: This covers all vte-based terminals, including Gnome Terminal, guake, Pantheon Terminal, Terminator, Tilix, XFCE Terminal.
 [^mux]: Unavailable as multiplexers (like tmux or screen) can be connected to multiple terminals (with different color settings) at the same time.
@@ -347,23 +347,23 @@ You can help improve this list! Check out [how to](ansi_compat.md) and open an i
 
 | Terminal         | Copy to Clipboard (OSC52) | Hyperlinks (OSC8) | Notifications (OSC777) |
 | ---------------- | :-----------------------: | :---------------: | :--------------------: |
-| alacritty        |             ✅            |  ❌[^alacritty]   |           ❌           |
-| foot             |             ✅            |        ✅         |           ✅           |
-| kitty            |             ✅            |        ✅         |           ✅           |
-| Konsole          |        ❌[^konsole]       |        ✅         |           ❌           |
-| rxvt             |             ❌            |        ❌         |           ❌           |
-| urxvt            |         ✅[^urxvt]        |        ❌         |           ✅           |
-| screen           |             ✅            |    ❌[^screen]    |           ❌           |
-| st               |             ✅            |        ❌         |           ❌           |
-| tmux             |             ✅            |     ❌[^tmux]     |           ❌           |
-| vte-based[^vte]  |          ❌[^vte]         |        ✅         |           ❌           |
-| wezterm          |             ✅            |        ✅         |           ❌           |
-| xterm            |             ✅            |        ❌         |           ❌           |
-| Linux Console    |             ⛔            |        ⛔         |           ❌           |
-| Apple Terminal   |         ✅[^apple]        |        ❌         |           ❌           |
-| iTerm            |             ✅            |        ✅         |           ❌           |
-| Windows cmd      |             ❌            |        ❌         |           ❌           |
-| Windows Terminal |             ✅            |        ✅         |           ❌           |
+| alacritty        |            ✅             |  ❌[^alacritty]   |           ❌           |
+| foot             |            ✅             |        ✅         |           ✅           |
+| kitty            |            ✅             |        ✅         |           ✅           |
+| Konsole          |       ❌[^konsole]        |        ✅         |           ❌           |
+| rxvt             |            ❌             |        ❌         |           ❌           |
+| urxvt            |        ✅[^urxvt]         |        ❌         |           ✅           |
+| screen           |            ✅             |    ❌[^screen]    |           ❌           |
+| st               |            ✅             |        ❌         |           ❌           |
+| tmux             |            ✅             |     ❌[^tmux]     |           ❌           |
+| vte-based[^vte]  |         ❌[^vte]          |        ✅         |           ❌           |
+| wezterm          |            ✅             |        ✅         |           ❌           |
+| xterm            |            ✅             |        ❌         |           ❌           |
+| Linux Console    |            ⛔             |        ⛔         |           ❌           |
+| Apple Terminal   |        ✅[^apple]         |        ❌         |           ❌           |
+| iTerm            |            ✅             |        ✅         |           ❌           |
+| Windows cmd      |            ❌             |        ❌         |           ❌           |
+| Windows Terminal |            ✅             |        ✅         |           ❌           |
 
 [^vte]: This covers all vte-based terminals, including Gnome Terminal, guake, Pantheon Terminal, Terminator, Tilix, XFCE Terminal. OSC52 is not supported, see [issue#2495](https://gitlab.gnome.org/GNOME/vte/-/issues/2495).
 [^urxvt]: Workaround for urxvt not supporting OSC52. See [this](https://unix.stackexchange.com/a/629485) for more information.
@@ -391,7 +391,6 @@ you need to enable ANSI processing in your application first:
 
 The above code is safe to include on non-Windows systems or when os.Stdout does
 not refer to a terminal (e.g. in tests).
-
 
 ## Color Chart
 

--- a/screen.go
+++ b/screen.go
@@ -32,16 +32,20 @@ const (
 	EraseEntireLineSeq = "2K"
 
 	// Mouse.
-	EnableMousePressSeq       = "?9h" // press only (X10)
-	DisableMousePressSeq      = "?9l"
-	EnableMouseSeq            = "?1000h" // press, release, wheel
-	DisableMouseSeq           = "?1000l"
-	EnableMouseHiliteSeq      = "?1001h" // highlight
-	DisableMouseHiliteSeq     = "?1001l"
-	EnableMouseCellMotionSeq  = "?1002h" // press, release, move on pressed, wheel
-	DisableMouseCellMotionSeq = "?1002l"
-	EnableMouseAllMotionSeq   = "?1003h" // press, release, move, wheel
-	DisableMouseAllMotionSeq  = "?1003l"
+	EnableMousePressSeq         = "?9h" // press only (X10)
+	DisableMousePressSeq        = "?9l"
+	EnableMouseSeq              = "?1000h" // press, release, wheel
+	DisableMouseSeq             = "?1000l"
+	EnableMouseHiliteSeq        = "?1001h" // highlight
+	DisableMouseHiliteSeq       = "?1001l"
+	EnableMouseCellMotionSeq    = "?1002h" // press, release, move on pressed, wheel
+	DisableMouseCellMotionSeq   = "?1002l"
+	EnableMouseAllMotionSeq     = "?1003h" // press, release, move, wheel
+	DisableMouseAllMotionSeq    = "?1003l"
+	EnableMouseExtendedModeSeq  = "?1006h" // press, release, move, wheel, extended coordinates
+	DisableMouseExtendedModeSeq = "?1006l"
+	EnableMousePixelsModeSeq    = "?1016h" // press, release, move, wheel, extended pixel coordinates
+	DisableMousePixelsModeSeq   = "?1016l"
 
 	// Screen.
 	RestoreScreenSeq = "?47l"
@@ -257,6 +261,29 @@ func (o Output) EnableMouseAllMotion() {
 // DisableMouseAllMotion disables All Motion Mouse mode.
 func (o Output) DisableMouseAllMotion() {
 	fmt.Fprint(o.tty, CSI+DisableMouseAllMotionSeq)
+}
+
+// EnableMouseExtendedMotion enables Extended Mouse mode (SGR). This should be
+// enabled in conjunction with EnableMouseCellMotion, and EnableMouseAllMotion.
+func (o Output) EnableMouseExtendedMode() {
+	fmt.Fprint(o.tty, CSI+EnableMouseExtendedModeSeq)
+}
+
+// DisableMouseExtendedMotion disables Extended Mouse mode (SGR).
+func (o Output) DisableMouseExtendedMode() {
+	fmt.Fprint(o.tty, CSI+DisableMouseExtendedModeSeq)
+}
+
+// EnableMousePixelsMotion enables Pixel Motion Mouse mode (SGR-Pixels). This
+// should be enabled in conjunction with EnableMouseCellMotion, and
+// EnableMouseAllMotion.
+func (o Output) EnableMousePixelsMode() {
+	fmt.Fprint(o.tty, CSI+EnableMousePixelsModeSeq)
+}
+
+// DisableMousePixelsMotion disables Pixel Motion Mouse mode (SGR-Pixels).
+func (o Output) DisableMousePixelsMode() {
+	fmt.Fprint(o.tty, CSI+DisableMousePixelsModeSeq)
 }
 
 // SetWindowTitle sets the terminal window title.


### PR DESCRIPTION
Add SGR and SGR-Pixels mouse support. Other modes are discouraged to use. UTF-8 only works for UTF-8 locales and there is no way to distinguish between previous mouse modes (< 1005). URxvt on the other hand only works in URxvt. Although some terminals support this protocol, they all support the newer SGR protocol.

SGR & SGR-Pixels modes must be enabled with basic terminal modes like cell motion (1002) and all motion (1003).

Reference: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Extended-coordinates
Reference: http://midnight-commander.org/ticket/2662
Reference: https://github.com/xtermjs/xterm.js/issues/1962
Reference: https://gitlab.gnome.org/GNOME/vte/-/issues/155
Reference: https://bugs.gentoo.org/761787