### PR TITLE
fix: compiling js/wasm/plan9/aix failed missing method ColorProfile 

### DIFF
--- a/termenv_other.go
+++ b/termenv_other.go
@@ -3,6 +3,8 @@
 
 package termenv
 
+import "io"
+
 func colorProfile() Profile {
 	return ANSI256
 }
@@ -15,4 +17,18 @@ func (o Output) foregroundColor() Color {
 func (o Output) backgroundColor() Color {
 	// default black
 	return ANSIColor(0)
+}
+
+// ColorProfile returns the supported color profile:
+// Default ANSI
+func (o *Output) ColorProfile() Profile {
+	return ANSI
+}
+
+// EnableVirtualTerminalProcessing enables virtual terminal processing on
+// Windows for w and returns a function that restores w to its previous state.
+// On non-Windows platforms, or if w does not refer to a terminal, then it
+// returns a non-nil no-op function and no error.
+func EnableVirtualTerminalProcessing(w io.Writer) (func() error, error) {
+	return func() error { return nil }, nil
 }


### PR DESCRIPTION
fixed compiling wasm

trying to compile the hello-world to wasm failed: 
```
termenv/examples/hello-world>   GOOS=js GOARCH=wasm go build -o m main.go
../../termenv.go:41:16: output.ColorProfile undefined (type *Output has no field or method ColorProfile)
../../termenv.go:97:9: o.ColorProfile undefined (type *Output has no field or method ColorProfile)
```

also:
`./main.go:10:33: undefined: termenv.EnableVirtualTerminalProcessing
`

after this PR:
it compiles...

