### PR TITLE
Add WithIsTTY option to inject isTTY value

### DIFF
--- a/output.go
+++ b/output.go
@@ -28,6 +28,7 @@ type Output struct {
 	fgColor Color
 	bgSync  *sync.Once
 	bgColor Color
+	isTty   *bool
 }
 
 // Environ is an interface for getting environment variables.
@@ -96,6 +97,13 @@ func WithColorCache(v bool) func(*Output) {
 		// cache the values now
 		_ = o.ForegroundColor()
 		_ = o.BackgroundColor()
+	}
+}
+
+// WithIsTTY returns a new Output with isTTY set to the given value.
+func WithIsTTY(v bool) func(*Output) {
+	return func(o *Output) {
+		o.isTty = &v
 	}
 }
 

--- a/termenv.go
+++ b/termenv.go
@@ -25,6 +25,10 @@ const (
 )
 
 func (o *Output) isTTY() bool {
+	if o.isTty != nil {
+		return *o.isTty
+	}
+
 	if len(o.environ.Getenv("CI")) > 0 {
 		return false
 	}

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -405,3 +405,21 @@ func TestEnableVirtualTerminalProcessing(t *testing.T) {
 		t.Fatalf("expected <nil>, got %v", err)
 	}
 }
+
+func TestWithIsTTY(t *testing.T) {
+	{
+		o := NewOutput(os.Stdout, WithIsTTY(true))
+
+		if o.isTTY() != true {
+			t.Errorf("Expected isTTY is true, got %b", o.isTty)
+		}
+	}
+
+	{
+		o := NewOutput(os.Stdout, WithIsTTY(false))
+
+		if o.isTTY() != false {
+			t.Errorf("Expected isTTY is false, got %b", o.isTty)
+		}
+	}
+}


### PR DESCRIPTION
Close https://github.com/muesli/termenv/issues/105

I've added `WIthIsTTY` option to control the Output's `isTTY` value.