### PR TITLE
Add GoReleaser and build for other OSs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,24 @@
 name: build
 on: [push, pull_request]
 jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1
+          cache: true
+          check-latest: true
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          distribution: goreleaser
+          args: release --rm-dist --snapshot --skip-sign --skip-sbom
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ^1
+        cache: true
+        check-latest: true
+    - uses: goreleaser/goreleaser-action@v4
+      with:
+        version: latest
+        distribution: goreleaser
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# GoReleaser
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+before:
+  hooks: ['go mod tidy']
+builds:
+  - no_main_check: true
+    goos:
+      - windows
+      - darwin
+      - linux
+      - solaris
+      - dragonfly
+      - freebsd
+      - netbsd
+      - openbsd
+      - plan9
+      - js
+      - aix
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+    - '^test:'
+    - '^chore'
+    - 'merge conflict'
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+    - go mod tidy
+  groups:
+    - title: Dependency updates
+      regexp: "^.*feat\\(deps\\)*:+.*$"
+      order: 300
+    - title: 'New Features'
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 100
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 200
+    - title: 'Documentation updates'
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 400
+    - title: Other work
+      order: 9999
+release:
+  skip_upload: true
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
- Add GoReleaser to handle building for different OSs
- Push a new tag to trigger a new release using GoReleaser