### PR TITLE
fix(output): tmux supports OSC 10 & 11

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -224,10 +224,10 @@ func (o *Output) readNextResponse() (response string, isOSC bool, err error) {
 }
 
 func (o Output) termStatusReport(sequence int) (string, error) {
-	// screen/tmux can't support OSC, because they can be connected to multiple
+	// screen can't support OSC, because they can be connected to multiple
 	// terminals concurrently.
 	term := o.environ.Getenv("TERM")
-	if strings.HasPrefix(term, "screen") || strings.HasPrefix(term, "tmux") {
+	if strings.HasPrefix(term, "screen") {
 		return "", ErrStatusReport
 	}
 


### PR DESCRIPTION
Tmux supports OSC 10 & 11 since tmux 2.6 https://github.com/tmux/tmux/blob/b55f34029ac05474dfd993c187b9c61bbcd4e1a1/CHANGES#L1164