### PR TITLE
fix: Cloud Shell supports RGB colors

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -25,6 +25,10 @@ func (o *Output) ColorProfile() Profile {
 		return Ascii
 	}
 
+	if o.environ.Getenv("GOOGLE_CLOUD_SHELL") == "true" {
+		return TrueColor
+	}
+
 	term := o.environ.Getenv("TERM")
 	colorTerm := o.environ.Getenv("COLORTERM")
 


### PR DESCRIPTION
Even tho `TERM` and `COLORTERM` aren't properly set, it supports the TrueColor profile.