### PR TITLE
fix(output): use withcolorcache on the default output

### DIFF
--- a/output.go
+++ b/output.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// output is the default global output.
-	output = NewOutput(os.Stdout)
+	output = NewOutput(os.Stdout, WithColorCache(true))
 )
 
 // File represents a file descriptor.

--- a/output.go
+++ b/output.go
@@ -105,10 +105,6 @@ func WithProfile(profile Profile) OutputOption {
 func WithColorCache(v bool) OutputOption {
 	return func(o *Output) {
 		o.cache = v
-
-		// cache the values now
-		_ = o.ForegroundColor()
-		_ = o.BackgroundColor()
 	}
 }
 


### PR DESCRIPTION
This should reduce how many times an application query the terminal for the background.

This also fixes querying the terminal when the `WithColorCache` option is invoked. We don't need to cache the fg/bg colors when we instantiate a termenv.Output, instead, lazy cache the colors whenever they're requested.