### PR TITLE
fix: wezterm is truecolor

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -50,7 +50,7 @@ func (o *Output) ColorProfile() Profile {
 	}
 
 	switch term {
-	case "xterm-kitty":
+	case "xterm-kitty", "wezterm":
 		return TrueColor
 	case "linux":
 		return ANSI


### PR DESCRIPTION
Wezterm supports truecolor.

Usually it sets `TERM` to `xterm-256color`, but you can also set it to `wezterm` and import its [terminfo](https://raw.githubusercontent.com/wez/wezterm/master/termwiz/data/wezterm.terminfo) with `tic` (which will then enable all term features in nvim et al)