### PR TITLE
fix: cache the color profile

### DIFF
--- a/output.go
+++ b/output.go
@@ -133,6 +133,11 @@ func WithUnsafe() OutputOption {
 	}
 }
 
+// ColorProfile returns the supported color profile:
+func (o Output) ColorProfile() Profile {
+	return o.Profile
+}
+
 // ForegroundColor returns the terminal's default foreground color.
 func (o *Output) ForegroundColor() Color {
 	f := func() {

--- a/termenv.go
+++ b/termenv.go
@@ -80,7 +80,8 @@ func EnvNoColor() bool {
 // EnvColorProfile returns the color profile based on environment variables set
 // Supports NO_COLOR (https://no-color.org/)
 // and CLICOLOR/CLICOLOR_FORCE (https://bixense.com/clicolors/)
-// If none of these environment variables are set, this behaves the same as ColorProfile()
+// If none of these environment variables are set, this behaves the same as
+// determining the color profile from the TERM environment variable.
 // It will return the Ascii color profile if EnvNoColor() returns true
 // If the terminal does not support any colors, but CLICOLOR_FORCE is set and not "0"
 // then the ANSI color profile will be returned.
@@ -91,7 +92,8 @@ func EnvColorProfile() Profile {
 // EnvColorProfile returns the color profile based on environment variables set
 // Supports NO_COLOR (https://no-color.org/)
 // and CLICOLOR/CLICOLOR_FORCE (https://bixense.com/clicolors/)
-// If none of these environment variables are set, this behaves the same as ColorProfile()
+// If none of these environment variables are set, this behaves the same as
+// determining the color profile from the TERM environment variable.
 // It will return the Ascii color profile if EnvNoColor() returns true
 // If the terminal does not support any colors, but CLICOLOR_FORCE is set and not "0"
 // then the ANSI color profile will be returned.
@@ -99,7 +101,7 @@ func (o *Output) EnvColorProfile() Profile {
 	if o.EnvNoColor() {
 		return Ascii
 	}
-	p := o.ColorProfile()
+	p := o.termColorProfile()
 	if o.cliColorForced() && p == Ascii {
 		return ANSI
 	}

--- a/termenv_other.go
+++ b/termenv_other.go
@@ -5,9 +5,9 @@ package termenv
 
 import "io"
 
-// ColorProfile returns the supported color profile:
-// ANSI256
-func (o Output) ColorProfile() Profile {
+// termColorProfile returns the supported color profile from the TERM
+// environment variable.
+func (o Output) termColorProfile() Profile {
 	return ANSI256
 }
 

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -18,9 +18,9 @@ const (
 	OSCTimeout = 5 * time.Second
 )
 
-// ColorProfile returns the supported color profile:
-// Ascii, ANSI, ANSI256, or TrueColor.
-func (o *Output) ColorProfile() Profile {
+// termColorProfile returns the supported color profile from the TERM
+// environment variable.
+func (o *Output) termColorProfile() Profile {
 	if !o.isTTY() {
 		return Ascii
 	}

--- a/termenv_windows.go
+++ b/termenv_windows.go
@@ -10,7 +10,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func (o *Output) ColorProfile() Profile {
+// termColorProfile returns the supported color profile from TERM environment:
+func (o *Output) termColorProfile() Profile {
 	if !o.isTTY() {
 		return Ascii
 	}


### PR DESCRIPTION
No need to query the environment every time we access the color profile.