### PR TITLE
fix(termenv): prevent hang in Emacs shell

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -227,7 +227,7 @@ func (o Output) termStatusReport(sequence int) (string, error) {
 	// screen/tmux can't support OSC, because they can be connected to multiple
 	// terminals concurrently.
 	term := o.environ.Getenv("TERM")
-	if strings.HasPrefix(term, "screen") || strings.HasPrefix(term, "tmux") {
+	if strings.HasPrefix(term, "screen") || strings.HasPrefix(term, "tmux") || strings.HasPrefix(term, "dumb") {
 		return "", ErrStatusReport
 	}
 


### PR DESCRIPTION
I noticed [lefthook](https://github.com/evilmartians/lefthook) was hanging for several seconds when running inside Emacs shell. I tracked it down to `termenv` via [lipgloss](https://github.com/charmbracelet/lipgloss). 

This PR fixes the delay by adding a check for `TERM=dumb`, which is the default in Emacs shell, as it's already done for `TERM=tmux` and `TERM=screen`.

Before:

[Screencast from 2023-09-15 19-24-17.webm](https://github.com/muesli/termenv/assets/19322/8ded02e3-4b7d-431e-8fc6-2ad69b21dfe5)

After:

[Screencast from 2023-09-15 19-23-34.webm](https://github.com/muesli/termenv/assets/19322/a9e9cfad-1e05-4137-9b87-6b2b34be0ccc)

