### PR TITLE
Implement Enable/Disable/Detect Kitty Keyboard Protocol

### DIFF
--- a/ansicolors.go
+++ b/ansicolors.go
@@ -1,6 +1,6 @@
 package termenv
 
-// ANSI color codes
+// ANSI color codes.
 const (
 	ANSIBlack ANSIColor = iota
 	ANSIRed

--- a/color.go
+++ b/color.go
@@ -14,7 +14,7 @@ var (
 	ErrInvalidColor = errors.New("invalid color")
 )
 
-// Foreground and Background sequence codes
+// Foreground and Background sequence codes.
 const (
 	Foreground = "38"
 	Background = "48"

--- a/profile.go
+++ b/profile.go
@@ -12,13 +12,13 @@ import (
 type Profile int
 
 const (
-	// TrueColor, 24-bit color profile
+	// TrueColor, 24-bit color profile.
 	TrueColor = Profile(iota)
-	// ANSI256, 8-bit color profile
+	// ANSI256, 8-bit color profile.
 	ANSI256
-	// ANSI, 4-bit color profile
+	// ANSI, 4-bit color profile.
 	ANSI
-	// Ascii, uncolored profile
+	// Ascii, uncolored profile.
 	Ascii //nolint:revive
 )
 

--- a/screen.go
+++ b/screen.go
@@ -60,6 +60,11 @@ const (
 	StartBracketedPasteSeq   = "200~"
 	EndBracketedPasteSeq     = "201~"
 
+	// Kitty Keyboard Protocol.
+	// https://sw.kovidgoyal.net/kitty/keyboard-protocol
+	EnableKittyKeyboardProtocol  = ">1u"
+	DisableKittyKeyboardProtocol = "<u"
+
 	// Session.
 	SetWindowTitleSeq     = "2;%s" + string(BEL)
 	SetForegroundColorSeq = "10;%s" + string(BEL)
@@ -299,6 +304,16 @@ func (o Output) EnableBracketedPaste() {
 // DisableBracketedPaste disables bracketed paste.
 func (o Output) DisableBracketedPaste() {
 	fmt.Fprintf(o.w, CSI+DisableBracketedPasteSeq)
+}
+
+// EnableKittyKeyboardProtocol enables the kitty keyboard protocol.
+func (o Output) EnableKittyKeyboardProtocol() {
+	fmt.Fprintf(o.w, CSI+EnableKittyKeyboardProtocol)
+}
+
+// DisableKittyKeyboardProtocol disables the kitty keyboard protocol.
+func (o Output) DisableKittyKeyboardProtocol() {
+	fmt.Fprintf(o.w, CSI+DisableKittyKeyboardProtocol)
 }
 
 // Legacy functions.

--- a/termenv.go
+++ b/termenv.go
@@ -13,15 +13,15 @@ var (
 )
 
 const (
-	// Escape character
+	// Escape character.
 	ESC = '\x1b'
-	// Bell
+	// Bell.
 	BEL = '\a'
-	// Control Sequence Introducer
+	// Control Sequence Introducer.
 	CSI = string(ESC) + "["
-	// Operating System Command
+	// Operating System Command.
 	OSC = string(ESC) + "]"
-	// String Terminator
+	// String Terminator.
 	ST = string(ESC) + `\`
 )
 

--- a/termenv_windows.go
+++ b/termenv_windows.go
@@ -54,6 +54,11 @@ func (o Output) backgroundColor() Color {
 	return ANSIColor(0)
 }
 
+func (o Output) kittyKeyboardProtocolSupport() byte {
+	// default byte
+	return 0b00000
+}
+
 // EnableWindowsANSIConsole enables virtual terminal processing on Windows
 // platforms. This allows the use of ANSI escape sequences in Windows console
 // applications. Ensure this gets called before anything gets rendered with


### PR DESCRIPTION
This PR allows for enabling and disabling kitty keyboard protocol.

https://sw.kovidgoyal.net/kitty/keyboard-protocol/

This PR adds for returning the progressive enhancements so that the terminal
application can detect which features are supported.

```go
KittyKeyboardProtocolSupport() byte
```

The byte returned represents the bitset of supported flags.

```
0b1     (01) — Disambiguate escape codes
0b10    (02) — Report event types
0b100   (04) — Report alternate keys
0b1000  (08) — Report all keys as escape codes
0b10000 (16) — Report associated text
```
