### PR TITLE
fix: do not use ioutil and other fixes

### DIFF
--- a/screen_test.go
+++ b/screen_test.go
@@ -2,7 +2,7 @@ package termenv
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -24,7 +24,7 @@ func (te testEnv) Getenv(key string) string {
 func tempOutput(t *testing.T) *Output {
 	t.Helper()
 
-	f, err := ioutil.TempFile("", "termenv")
+	f, err := os.CreateTemp("", "termenv")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,13 +40,13 @@ func verify(t *testing.T, o *Output, exp string) {
 		t.Fatal(err)
 	}
 
-	b, err := ioutil.ReadAll(tty)
+	b, err := io.ReadAll(tty)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(b) != exp {
-		b = bytes.Replace(b, []byte("\x1b"), []byte("\\x1b"), -1)
-		exp = strings.Replace(exp, "\x1b", "\\x1b", -1)
+		b = bytes.ReplaceAll(b, []byte("\x1b"), []byte("\\x1b"))
+		exp = strings.ReplaceAll(exp, "\x1b", "\\x1b")
 		t.Errorf("output does not match, expected %s, got %s", exp, string(b))
 	}
 

--- a/templatehelper_test.go
+++ b/templatehelper_test.go
@@ -3,7 +3,7 @@ package termenv
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"text/template"
 )
@@ -31,7 +31,7 @@ func TestTemplateFuncs(t *testing.T) {
 			}
 			actual := buf.Bytes()
 			filename := fmt.Sprintf("./testdata/templatehelper_%s.txt", test.name)
-			expected, err := ioutil.ReadFile(filename)
+			expected, err := os.ReadFile(filename)
 			if err != nil {
 				t.Fatalf("unexpected error reading golden file %q: %v", filename, err)
 			}

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image/color"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -312,8 +312,8 @@ func TestTemplateHelpers(t *testing.T) {
 		}
 
 		if buf.String() != v.Expected {
-			v1 := strings.Replace(v.Expected, "\x1b", "", -1)
-			v2 := strings.Replace(buf.String(), "\x1b", "", -1)
+			v1 := strings.ReplaceAll(v.Expected, "\x1b", "")
+			v2 := strings.ReplaceAll(buf.String(), "\x1b", "")
 			t.Errorf("Expected %s, got %s", v1, v2)
 		}
 	}
@@ -409,7 +409,7 @@ func TestEnableVirtualTerminalProcessing(t *testing.T) {
 
 func TestWithTTY(t *testing.T) {
 	for _, v := range []bool{true, false} {
-		o := NewOutput(ioutil.Discard, WithTTY(v))
+		o := NewOutput(io.Discard, WithTTY(v))
 		if o.isTTY() != v {
 			t.Fatalf("expected WithTTY(%t) to set isTTY to %t", v, v)
 		}


### PR DESCRIPTION
- do not use `io/ioutil` (deprecated)
- use `[strings|bytes]ReplaceAll(x,y)` instead of `[strings|bytes]Replace(x,y,-1)`