### PR TITLE
Add support for building on z/OS

### DIFF
--- a/constants_zos.go
+++ b/constants_zos.go
@@ -1,0 +1,8 @@
+package termenv
+
+import "golang.org/x/sys/unix"
+
+const (
+	tcgetattr = unix.TCGETS
+	tcsetattr = unix.TCSETS
+)

--- a/termenv_posix.go
+++ b/termenv_posix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || zos
+// +build darwin dragonfly freebsd linux netbsd openbsd zos
 
 package termenv
 

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris zos
 
 package termenv
 


### PR DESCRIPTION
Enables termenv to be built on z/OS :)

z/OS uses the same constants as `constants_linux.go` but because its selectively built based on filename instead of tags I needed to copy them to `constants_zos.go`