### PR TITLE
add support for GOARCH=wasm (include GOOS=wasip1)

### DIFF
--- a/termenv_other.go
+++ b/termenv_other.go
@@ -1,5 +1,5 @@
-//go:build js || plan9 || aix
-// +build js plan9 aix
+//go:build wasm || plan9 || aix
+// +build wasm plan9 aix
 
 package termenv
 

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -6,14 +6,22 @@ import (
 	"image/color"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"text/template"
 )
 
+const isOtherPlatform = runtime.GOOS == "plan9" || runtime.GOOS == "aix" || runtime.GOARCH == "wasm"
+
 func TestLegacyTermEnv(t *testing.T) {
 	p := ColorProfile()
-	if p != TrueColor && p != Ascii {
+
+	if isOtherPlatform {
+		if p != ANSI256 {
+			t.Errorf("Expected %d, got %d", ANSI256, p)
+		}
+	} else if p != TrueColor && p != Ascii {
 		t.Errorf("Expected %d, got %d", TrueColor, p)
 	}
 
@@ -36,7 +44,12 @@ func TestLegacyTermEnv(t *testing.T) {
 
 func TestTermEnv(t *testing.T) {
 	o := NewOutput(os.Stdout)
-	if o.Profile != TrueColor && o.Profile != Ascii {
+
+	if isOtherPlatform {
+		if o.Profile != ANSI256 {
+			t.Errorf("Expected %d, got %d", ANSI256, o.Profile)
+		}
+	} else if o.Profile != TrueColor && o.Profile != Ascii {
 		t.Errorf("Expected %d, got %d", TrueColor, o.Profile)
 	}
 
@@ -358,6 +371,10 @@ func TestEnvNoColor(t *testing.T) {
 }
 
 func TestPseudoTerm(t *testing.T) {
+	if isOtherPlatform {
+		t.Skip("does not pass on platforms that default to ANSI256")
+	}
+
 	buf := &bytes.Buffer{}
 	o := NewOutput(buf)
 	if o.Profile != Ascii {


### PR DESCRIPTION
termenv compiles where `GOOS=js`, but fails with `GOOS=wasip1` (https://go.dev/blog/wasi). This patch treats wasip1 as js, which for these purposes should be correct.

I was able to run the tests on wasip1 by installing wazero and setting `WASMRUNTIME=wazero`. The tests failed, when I first ran them, but it looks like the tests make assumptions that would fail for all of the `_other` targets. This patch also "fixes" the tests (it skips one I wasn't sure how to rewrite for this platform).

A project I'm working on imports this library as a transitive dependency, without this termenv does not build on GOOS=wasip1.

I decided to target wasm rather than js and wasip1 because more GOOS values will probably be added for wasm in the future, but it seems unlikely that wasm will end up running full operating systems tag like 'unix' would apply to.