### PR TITLE
fix: allow to termStatusReport on a PTY

### DIFF
--- a/output.go
+++ b/output.go
@@ -6,10 +6,8 @@ import (
 	"sync"
 )
 
-var (
-	// output is the default global output.
-	output = NewOutput(os.Stdout)
-)
+// output is the default global output.
+var output = NewOutput(os.Stdout)
 
 // File represents a file descriptor.
 //

--- a/termenv_posix.go
+++ b/termenv_posix.go
@@ -2,16 +2,3 @@
 // +build darwin dragonfly freebsd linux netbsd openbsd zos
 
 package termenv
-
-import (
-	"golang.org/x/sys/unix"
-)
-
-func isForeground(fd int) bool {
-	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
-	if err != nil {
-		return false
-	}
-
-	return pgrp == unix.Getpgrp()
-}

--- a/termenv_solaris.go
+++ b/termenv_solaris.go
@@ -2,21 +2,3 @@
 // +build solaris illumos
 
 package termenv
-
-import (
-	"golang.org/x/sys/unix"
-)
-
-func isForeground(fd int) bool {
-	pgrp, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
-	if err != nil {
-		return false
-	}
-
-	g, err := unix.Getpgrp()
-	if err != nil {
-		return false
-	}
-
-	return pgrp == g
-}

--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -238,11 +238,6 @@ func (o Output) termStatusReport(sequence int) (string, error) {
 
 	if !o.unsafe {
 		fd := int(tty.Fd())
-		// if in background, we can't control the terminal
-		if !isForeground(fd) {
-			return "", ErrStatusReport
-		}
-
 		t, err := unix.IoctlGetTermios(fd, tcgetattr)
 		if err != nil {
 			return "", fmt.Errorf("%s: %s", ErrStatusReport, err)


### PR DESCRIPTION
A pty is not in foreground, but it can do the IOCTL ops we need.

My understanding might be wrong, but I think that if the term cannot do the TCGETS it will fail the same way it would when checking if its in foreground, so maybe that check is even needed?

refs https://github.com/charmbracelet/wish/issues/262