### PR TITLE
feat: mark more term as truecolor

### DIFF
--- a/termenv_unix.go
+++ b/termenv_unix.go
@@ -50,7 +50,12 @@ func (o *Output) ColorProfile() Profile {
 	}
 
 	switch term {
-	case "xterm-kitty", "wezterm", "xterm-ghostty":
+	case
+		"alacritty",
+		"contour",
+		"wezterm",
+		"xterm-ghostty",
+		"xterm-kitty":
 		return TrueColor
 	case "linux":
 		return ANSI


### PR DESCRIPTION
I dig into the src of almost all terms listed [here](https://github.com/termstandard/colors?tab=readme-ov-file#fully-supporting)

most of them set `TERM=xterm-256color COLORTERM=truecolor`, but some set `TERM=<their name>`, in which case we can handle it here.

This helps specially in SSH sessions, as `COLORTERM` is not sent by default.