### PR TITLE
Classify Terminals & Use Classification

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -1,17 +1,16 @@
 package termenv
 
 import (
-	"strings"
-
 	"github.com/aymanbagabas/go-osc52/v2"
 )
 
 // Copy copies text to clipboard using OSC 52 escape sequence.
 func (o Output) Copy(str string) {
 	s := osc52.New(str)
-	if strings.HasPrefix(o.environ.Getenv("TERM"), "screen") {
+	if o.TerminalIdentity == GNUScreen {
 		s = s.Screen()
 	}
+
 	_, _ = s.WriteTo(o)
 }
 
@@ -19,7 +18,7 @@ func (o Output) Copy(str string) {
 // sequence.
 func (o Output) CopyPrimary(str string) {
 	s := osc52.New(str).Primary()
-	if strings.HasPrefix(o.environ.Getenv("TERM"), "screen") {
+	if o.TerminalIdentity == GNUScreen {
 		s = s.Screen()
 	}
 	_, _ = s.WriteTo(o)

--- a/identity.go
+++ b/identity.go
@@ -16,7 +16,7 @@ const (
 	DumbTerminal
 	// GoogleCloudShell is a browser-based CLI for GCP
 	GoogleCloudShell
-	// WindowsTerminalHosted indicates a terminal operating as a Windows Terminal tab
+	// WindowsTerminalHosted indicates a terminal operating as a Windows Terminal tab.
 	WindowsTerminalHosted
 	// XTermCompatible means that the terminal has identified itself as being xterm, which may or may not be true
 	XTermCompatible

--- a/identity.go
+++ b/identity.go
@@ -1,0 +1,48 @@
+package termenv
+
+// TerminalIdentity is a guesstimate of a vague category of terminals that this program is running in. It should
+// not be considered definitive, some categories overlap, and terminals also lie about this stuff all the time.
+//
+// It's used to get a general sense of certain things.  For instance, dumb terminals absolutely won't respond to cursor
+// queries, and GNU Screen will sometimes say that it supports truecolor when it doesn't.
+type TerminalIdentity int
+
+const (
+	// GNUScreen is a terminal multiplexer released in 1987
+	GNUScreen TerminalIdentity = iota
+	// TMux is a terminal multiplexer released in 2007
+	TMux
+	// DumbTerminal indicates a terminal with no capabilities- some embedded terminals identify themselves this way
+	DumbTerminal
+	// GoogleCloudShell is a browser-based CLI for GCP
+	GoogleCloudShell
+	// WindowsTerminalHosted indicates a terminal operating as a Windows Terminal tab
+	WindowsTerminalHosted
+	// XTermCompatible means that the terminal has identified itself as being xterm, which may or may not be true
+	XTermCompatible
+	// OtherWindows means PowerShell or Windows' CMD, running standalone
+	OtherWindows
+	// OtherTerminal means any terminal that does not belong to one of the above categories
+	OtherTerminal
+)
+
+func (i TerminalIdentity) String() string {
+	switch i {
+	case GNUScreen:
+		return "GNUScreen"
+	case TMux:
+		return "TMux"
+	case DumbTerminal:
+		return "DumbTerminal"
+	case GoogleCloudShell:
+		return "GoogleCloudShell"
+	case WindowsTerminalHosted:
+		return "WindowsTerminalHosted"
+	case XTermCompatible:
+		return "XTermCompatible"
+	case OtherWindows:
+		return "OtherWindows"
+	default:
+		return "OtherTerminal"
+	}
+}

--- a/identity_test.go
+++ b/identity_test.go
@@ -1,0 +1,108 @@
+package termenv
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestTerminalIdentity(t *testing.T) {
+	testCases := map[string]struct {
+		Env              testEnv
+		ExpectedIdentity TerminalIdentity
+	}{
+		"Google Cloud Shell": {
+			testEnv{
+				"GOOGLE_CLOUD_SHELL": "true",
+			},
+			GoogleCloudShell,
+		},
+		"Other": {
+			testEnv{},
+			OtherTerminal,
+		},
+		"Windows Terminal": {
+			testEnv{
+				"WT_SESSION": "aec55a8a-d1c8-48a9-93f9-65da8c5e468d",
+				"GOOS":       "windows",
+			},
+			WindowsTerminalHosted,
+		},
+		"Windows Terminal Hosting XTerm Compatible": {
+			testEnv{
+				"WT_SESSION": "aec55a8a-d1c8-48a9-93f9-65da8c5e468d",
+				"GOOS":       "windows",
+				"TERM":       "xterm-256color",
+			},
+			WindowsTerminalHosted,
+		},
+		"Windows Terminal Hosting WSL": {
+			testEnv{
+				"WT_SESSION": "aec55a8a-d1c8-48a9-93f9-65da8c5e468d",
+				"GOOS":       "linux",
+				"TERM":       "xterm-256color",
+			},
+			WindowsTerminalHosted,
+		},
+		"GNU Screen": {
+			testEnv{
+				"TERM": "screen-256color",
+			},
+			GNUScreen,
+		},
+		"TMux Pretending To Be Screen": {
+			testEnv{
+				"TERM":         "screen-256color",
+				"TERM_PROGRAM": "tmux",
+			},
+			TMux,
+		},
+		"TMux Being Honest": {
+			testEnv{
+				"TERM": "tmux-256color",
+			},
+			TMux,
+		},
+		"Dumb Terminal": {
+			testEnv{
+				"TERM": "dumb-256color",
+			},
+			DumbTerminal,
+		},
+		"XTerm Compatible": {
+			testEnv{
+				"TERM": "xterm-256color",
+			},
+			XTermCompatible,
+		},
+		"XTerm Compatible In Windows": {
+			testEnv{
+				"TERM": "xterm-256color",
+				"GOOS": "windows",
+			},
+			XTermCompatible,
+		},
+		"Windows Native Terminal": {
+			testEnv{
+				"GOOS": "windows",
+			},
+			OtherWindows,
+		},
+		"Wezterm": {
+			testEnv{
+				"TERM": "wezterm",
+			},
+			OtherTerminal,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output := NewOutput(bufio.NewWriter(bytes.NewBuffer(nil)), WithTTY(true), WithEnvironment(testCase.Env))
+
+			if output.TerminalIdentity != testCase.ExpectedIdentity {
+				t.Errorf("output does not match, expected %s, got %s", testCase.ExpectedIdentity, output.TerminalIdentity)
+			}
+		})
+	}
+}

--- a/output.go
+++ b/output.go
@@ -25,9 +25,9 @@ type OutputOption = func(*Output)
 // Output is a terminal output.
 type Output struct {
 	Profile
-	TerminalIdentity
-	w       io.Writer
-	environ Environ
+	TerminalIdentity TerminalIdentity
+	w                io.Writer
+	environ          Environ
 
 	assumeTTY bool
 	unsafe    bool

--- a/output.go
+++ b/output.go
@@ -25,6 +25,7 @@ type OutputOption = func(*Output)
 // Output is a terminal output.
 type Output struct {
 	Profile
+	TerminalIdentity
 	w       io.Writer
 	environ Environ
 
@@ -66,13 +67,14 @@ func SetDefaultOutput(o *Output) {
 // NewOutput returns a new Output for the given writer.
 func NewOutput(w io.Writer, opts ...OutputOption) *Output {
 	o := &Output{
-		w:       w,
-		environ: &osEnviron{},
-		Profile: -1,
-		fgSync:  &sync.Once{},
-		fgColor: NoColor{},
-		bgSync:  &sync.Once{},
-		bgColor: NoColor{},
+		w:                w,
+		environ:          &osEnviron{},
+		Profile:          -1,
+		TerminalIdentity: -1,
+		fgSync:           &sync.Once{},
+		fgColor:          NoColor{},
+		bgSync:           &sync.Once{},
+		bgColor:          NoColor{},
 	}
 
 	if o.w == nil {
@@ -80,6 +82,9 @@ func NewOutput(w io.Writer, opts ...OutputOption) *Output {
 	}
 	for _, opt := range opts {
 		opt(o)
+	}
+	if o.TerminalIdentity < 0 {
+		o.TerminalIdentity = o.EnvTerminalIdentity()
 	}
 	if o.Profile < 0 {
 		o.Profile = o.EnvColorProfile()

--- a/screen_test.go
+++ b/screen_test.go
@@ -2,23 +2,31 @@ package termenv
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
 )
 
-type testEnv struct{}
+type testEnv map[string]string
 
 func (te testEnv) Environ() []string {
-	return []string{"TERM=xterm-256color"}
+	var output []string
+	for key, value := range te {
+		output = append(output, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return output
 }
 
 func (te testEnv) Getenv(key string) string {
-	if key == "TERM" {
-		return "xterm-256color"
+	value, ok := te[key]
+	if !ok {
+		return ""
 	}
-	return ""
+
+	return value
 }
 
 func tempOutput(t *testing.T) *Output {
@@ -29,7 +37,9 @@ func tempOutput(t *testing.T) *Output {
 		t.Fatal(err)
 	}
 
-	return NewOutput(f, WithEnvironment(testEnv{}), WithProfile(TrueColor))
+	return NewOutput(f, WithEnvironment(testEnv{
+		"TERM": "xterm-256color",
+	}), WithProfile(TrueColor))
 }
 
 func verify(t *testing.T, o *Output, exp string) {


### PR DESCRIPTION
# Problem

Screen/TMux detection is a bit of an annoyance in this codebase, as evidenced by the fact that this code has been accidentally doing Screen encoding in Copy/CopyPrimary for TMux up until now.  

# Changes

I figured it would be nice to determine whether the output is tmux or screen up front, and decided to go ahead and consolidate terminal categorization into a single place, using an enum.  I fixed Copy/CopyPrimary to only do screen encoding for screen, as well and took the opportunity to move a few other codepoints over to use the enums.



