### PR TITLE
feat: add support for wasm

### DIFF
--- a/termenv_other.go
+++ b/termenv_other.go
@@ -1,5 +1,5 @@
-//go:build js || plan9 || aix
-// +build js plan9 aix
+//go:build js || plan9 || aix || wasm
+// +build js plan9 aix wasm
 
 package termenv
 


### PR DESCRIPTION
Hi,
I'm using lipgloss in WASM environment - at least I'm trying - and since lipgloss has dependency on termenv, I need termenv to support WASM as compilation target.