### PR TITLE
fix: prefer os.Stderr over os.Stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go get github.com/muesli/termenv
 ## Usage
 
 ```go
-output := termenv.NewOutput(os.Stdout)
+output := termenv.NewOutput(os.Stderr)
 ```
 
 `termenv` queries the terminal's capabilities it is running in, so you can
@@ -70,7 +70,7 @@ If you don't want to rely on the automatic detection, you can manually select
 the profile you want to use:
 
 ```go
-output := termenv.NewOutput(os.Stdout, termenv.WithProfile(termenv.TrueColor))
+output := termenv.NewOutput(os.Stderr, termenv.WithProfile(termenv.TrueColor))
 ```
 
 ## Colors
@@ -392,7 +392,7 @@ you need to enable ANSI processing in your application first:
     defer restoreConsole()
 ```
 
-The above code is safe to include on non-Windows systems or when os.Stdout does
+The above code is safe to include on non-Windows systems or when os.Stderr does
 not refer to a terminal (e.g. in tests).
 
 ## Color Chart

--- a/output.go
+++ b/output.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// output is the default global output.
-	output = NewOutput(os.Stdout)
+	output = NewOutput(os.Stderr)
 )
 
 // File represents a file descriptor.
@@ -76,7 +76,7 @@ func NewOutput(w io.Writer, opts ...OutputOption) *Output {
 	}
 
 	if o.w == nil {
-		o.w = os.Stdout
+		o.w = os.Stderr
 	}
 	for _, opt := range opts {
 		opt(o)

--- a/termenv_test.go
+++ b/termenv_test.go
@@ -35,7 +35,7 @@ func TestLegacyTermEnv(t *testing.T) {
 }
 
 func TestTermEnv(t *testing.T) {
-	o := NewOutput(os.Stdout)
+	o := NewOutput(os.Stderr)
 	if o.Profile != TrueColor && o.Profile != Ascii {
 		t.Errorf("Expected %d, got %d", TrueColor, o.Profile)
 	}
@@ -348,7 +348,7 @@ func TestEnvNoColor(t *testing.T) {
 			for i := 0; i < len(test.environ); i += 2 {
 				os.Setenv(test.environ[i], test.environ[i+1])
 			}
-			out := NewOutput(os.Stdout)
+			out := NewOutput(os.Stderr)
 			actual := out.EnvNoColor()
 			if test.expected != actual {
 				t.Errorf("expected %t but was %t", test.expected, actual)
@@ -387,7 +387,7 @@ func TestPseudoTerm(t *testing.T) {
 }
 
 func TestCache(t *testing.T) {
-	o := NewOutput(os.Stdout, WithColorCache(true), WithProfile(TrueColor))
+	o := NewOutput(os.Stderr, WithColorCache(true), WithProfile(TrueColor))
 
 	if o.cache != true {
 		t.Errorf("Expected cache to be active, got %t", o.cache)
@@ -397,7 +397,7 @@ func TestCache(t *testing.T) {
 func TestEnableVirtualTerminalProcessing(t *testing.T) {
 	// EnableVirtualTerminalProcessing should always return a non-nil
 	// restoreFunc, and in tests it should never return an error.
-	restoreFunc, err := EnableVirtualTerminalProcessing(NewOutput(os.Stdout))
+	restoreFunc, err := EnableVirtualTerminalProcessing(NewOutput(os.Stderr))
 	if restoreFunc == nil || err != nil {
 		t.Fatalf("expected non-<nil>, <nil>, got %p, %v", restoreFunc, err)
 	}


### PR DESCRIPTION
This allows feature detection to be a bit more resilient by default, since `stdout` can be piped to other destinations whereas `stderr` is usually pointed at the terminal.