### PR TITLE
add ability to return styled() without trailing reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
-module github.com/muesli/termenv
+module github.com/rahji/termenv
 
 go 1.17
+
+replace github.com/muesli/termenv => github.com/rahji/termenv v0.16.1
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/rivo/uniseg v0.4.7
 	golang.org/x/sys v0.30.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rahji/termenv
+module github.com/muesli/termenv
 
 go 1.17
 
@@ -8,7 +8,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/muesli/termenv v0.16.0
 	github.com/rivo/uniseg v0.4.7
 	golang.org/x/sys v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/rahji/termenv v0.16.1 h1:C+JCBu0FEh9uPayJIu9pJ+w90tT70mCxi/AzaD7UwlM=
-github.com/rahji/termenv v0.16.1/go.mod h1:jeqvVfGyGmpCFfP9fK4yIWvxcMb8ApE3EPBq5fCzaaU=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/rahji/termenv v0.16.1 h1:C+JCBu0FEh9uPayJIu9pJ+w90tT70mCxi/AzaD7UwlM=
+github.com/rahji/termenv v0.16.1/go.mod h1:jeqvVfGyGmpCFfP9fK4yIWvxcMb8ApE3EPBq5fCzaaU=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/style.go
+++ b/style.go
@@ -41,6 +41,16 @@ func (t Style) String() string {
 
 // Styled renders s with all applied styles.
 func (t Style) Styled(s string) string {
+	return t.styled(s, true)
+}
+
+// Styled renders s with all applied styles, but no trailing reset
+func (t Style) StyledWithoutReset(s string) string {
+	return t.styled(s, false)
+}
+
+// styled is a private function that is called by both Styled and StyledWithout Reset
+func (t Style) styled(s string, reset bool) string {
 	if t.profile == Ascii {
 		return s
 	}
@@ -53,7 +63,11 @@ func (t Style) Styled(s string) string {
 		return s
 	}
 
-	return fmt.Sprintf("%s%sm%s%sm", CSI, seq, s, CSI+ResetSeq)
+	var end string
+	if reset {
+		end = fmt.Sprintf("%s%sm", CSI, ResetSeq)
+	}
+	return fmt.Sprintf("%s%sm%s%s", CSI, seq, s, end)
 }
 
 // Foreground sets a foreground color.


### PR DESCRIPTION
I added a function called `StyledWithoutReset()` that works like `Styled()`, but without the trailing reset ANSI sequence. This is required if you wish to reduce redundant ANSI sequences in cases where text that you are outputting should use the previously sent style info.